### PR TITLE
remove all .v and .unv

### DIFF
--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -20,10 +20,10 @@
     dataset <- .readDataClassificationRegressionAnalyses(dataset, options)
   
   if (length(unlist(options[["predictors"]])) > 0 && options[["scaleEqualSD"]])
-    dataset[,.v(options[["predictors"]])] <- .scaleNumericData(dataset[,.v(options[["predictors"]]), drop = FALSE])
+    dataset[,options[["predictors"]]] <- .scaleNumericData(dataset[,options[["predictors"]], drop = FALSE])
   
   if (options[["target"]] != "")
-    dataset[, .v(options[["target"]])] <- factor(dataset[, .v(options[["target"]])])
+    dataset[, options[["target"]]] <- factor(dataset[, options[["target"]]])
   
   return(dataset)
 }
@@ -44,8 +44,8 @@
 }
 
 .classificationFormula <- function(options, jaspResults){
-  predictors <- .v(options[["predictors"]])
-  target <- .v(options[["target"]])
+  predictors <- options[["predictors"]]
+  target <- options[["target"]]
   formula <- formula(paste(target, "~", paste(predictors, collapse=" + ")))
   jaspResults[["formula"]] <- createJaspState(formula)
   jaspResults[["formula"]]$dependOn(options = c("predictors", "target"))
@@ -269,7 +269,7 @@
     confusionTable$addColumnInfo(name = "obs_name",    title = "", type = "string")
     confusionTable$addColumnInfo(name = "varname_obs", title = "", type = "string")
 
-    factorLevels <- levels(dataset[, .v(options[["target"]])])
+    factorLevels <- levels(dataset[, options[["target"]]])
     
     confusionTable[["obs_name"]] <- c(gettext("Observed"), rep("", length(factorLevels) - 1))
     confusionTable[["varname_obs"]] <- factorLevels
@@ -320,7 +320,7 @@
   classificationResult <- jaspResults[["classificationResult"]]$object
 
   variables <- options[["predictors"]]
-  variables <- variables[ !sapply(dataset[, .v(variables)], is.factor) ] # remove factors from boundary plot
+  variables <- variables[ !sapply(dataset[, variables], is.factor) ] # remove factors from boundary plot
   l <- length(variables)
 
   if(l < 2){ # Need at least 2 numeric variables to create a matrix
@@ -346,7 +346,7 @@
   oldFontSize <- jaspGraphs::getGraphOption("fontsize")
   jaspGraphs::setGraphOption("fontsize", .85 * oldFontSize)
   
-  target <- dataset[, .v(options[["target"]])]
+  target <- dataset[, options[["target"]]]
   startProgressbar(length(plotMat)+1)
 
   for (row in 2:l) {
@@ -360,9 +360,9 @@
           plotMat[[row, col]] <- p
       }  
       if (col < row) {
-          predictors <- dataset[, .v(variables)]
+          predictors <- dataset[, variables]
           predictors <- predictors[, c(col, row)]
-          formula <- formula(paste(.v(options[["target"]]), "~", paste(colnames(predictors), collapse=" + ")))
+          formula <- formula(paste(options[["target"]], "~", paste(colnames(predictors), collapse=" + ")))
           plotMat[[row-1, col]] <- .decisionBoundaryPlot(dataset, options, jaspResults, predictors, target, formula, l, type = type)
       } 
       if (col > row) {
@@ -453,8 +453,8 @@
 
 .legendPlot <- function(dataset, options, col){
 
-  target <- dataset[, .v(options[["target"]])]
-  predictors <- dataset[, .v(options[["predictors"]])]
+  target <- dataset[, options[["target"]]]
+  predictors <- dataset[, options[["predictors"]]]
   predictors <- predictors[, 1]
   lda.data <- data.frame(target = target, predictors = predictors)
   
@@ -491,9 +491,9 @@
     train <- classificationResult[["train"]]
     test <- classificationResult[["test"]]
 
-    lvls <- levels(factor(train[, .v(options[["target"]])]))
+    lvls <- levels(factor(train[, options[["target"]]]))
 
-    predictors <- .v(options[["predictors"]])
+    predictors <- options[["predictors"]]
     formula <- formula(paste("levelVar", "~", paste(predictors, collapse=" + ")))
 
     linedata <- data.frame(x = c(0,1), y = c(0,1))
@@ -508,12 +508,12 @@
 
     for(i in 1:length(lvls)){
 
-      levelVar <- train[,.v(options[["target"]])] == lvls[i]
+      levelVar <- train[,options[["target"]]] == lvls[i]
       typeData <- cbind(train, levelVar = factor(levelVar))
-      column <- which(colnames(typeData) == .v(options[["target"]]))
+      column <- which(colnames(typeData) == options[["target"]])
       typeData <- typeData[, -column]
 
-      actual.class <- test[,.v(options[["target"]])] == lvls[i]
+      actual.class <- test[,options[["target"]]] == lvls[i]
 
       if(length(levels(factor(actual.class))) != 2){ # This variable is not in the test set, we should skip it
         next
@@ -601,8 +601,8 @@
     sample <- 1:nrow(dataset)
   }
 
-  predictors <- dataset[sample, .v(options[["predictors"]])]
-  target <- dataset[sample, .v(options[["target"]])]
+  predictors <- dataset[sample, options[["predictors"]]]
+  target <- dataset[sample, options[["target"]]]
 
   # Taken from function `andrewsplot()` in R package "andrewsplot", thanks!
   n <- nrow(predictors)
@@ -709,7 +709,7 @@
   validationMeasures$addFootnote(gettext("Area Under Curve (AUC) is calculated for every class against all other classes."))
 
   if(options[["target"]] != "")
-    validationMeasures[["group"]] <- c(levels(factor(dataset[, .v(options[["target"]])])), gettext("Average / Total"))
+    validationMeasures[["group"]] <- c(levels(factor(dataset[, options[["target"]]])), gettext("Average / Total"))
   
   jaspResults[["validationMeasures"]] <- validationMeasures
 
@@ -751,7 +751,7 @@
   support[length(support) + 1]        <- sum(support, na.rm = TRUE)
   auc[length(auc) + 1]                <- mean(auc, na.rm = TRUE)
 
-  validationMeasures[["group"]]       <- c(levels(factor(classificationResult[["test"]][, .v(options[["target"]])])), "Average / Total") # fill again to adjust for missing categories
+  validationMeasures[["group"]]       <- c(levels(factor(classificationResult[["test"]][, options[["target"]]])), "Average / Total") # fill again to adjust for missing categories
   validationMeasures[["precision"]]   <- precision
   validationMeasures[["recall"]]      <- recall
   validationMeasures[["f1"]]          <- f1
@@ -788,8 +788,8 @@
   classProportionsTable$addColumnInfo(name = "test", title = gettext("Test Set"), type = "number")
 
   if(options[["target"]] != ""){
-    classProportionsTable[["group"]] <- levels(factor(dataset[, .v(options[["target"]])]))
-    Dlevels <- levels(factor(dataset[, .v(options[["target"]])]))
+    classProportionsTable[["group"]] <- levels(factor(dataset[, options[["target"]]]))
+    Dlevels <- levels(factor(dataset[, options[["target"]]]))
   }
   
   jaspResults[["classProportionsTable"]] <- classProportionsTable
@@ -804,11 +804,11 @@
     validValues     <- rep(0, length(classProportionsTable[["group"]]))
   testValues      <- rep(0, length(classProportionsTable[["group"]]))
 
-  dataTable       <- prop.table(table(dataset[,.v(options[["target"]])]))
-  trainingTable   <- prop.table(table(classificationResult[["train"]][,.v(options[["target"]])]))
+  dataTable       <- prop.table(table(dataset[,options[["target"]]]))
+  trainingTable   <- prop.table(table(classificationResult[["train"]][,options[["target"]]]))
   if(options[["modelOpt"]] != "optimizationManual")
-    validTable      <- prop.table(table(classificationResult[["valid"]][,.v(options[["target"]])]))
-  testTable       <- prop.table(table(classificationResult[["test"]][,.v(options[["target"]])]))
+    validTable      <- prop.table(table(classificationResult[["valid"]][,options[["target"]]]))
+  testTable       <- prop.table(table(classificationResult[["test"]][,options[["target"]]]))
 
   for(i in 1:length(Dlevels)){
     # Dataset
@@ -859,22 +859,22 @@
 }
 
 .classificationCalcAUC <- function(test, train, options, class, ...) {
-  lvls <- levels(factor(test[, .v(options[["target"]])]))
+  lvls <- levels(factor(test[, options[["target"]]]))
   auc <- numeric(length(lvls)) 
 
-  predictorNames <- .v(options[["predictors"]])
+  predictorNames <- options[["predictors"]]
   AUCformula <- formula(paste("levelVar", "~", paste(predictorNames, collapse=" + ")))
   class(AUCformula) <- c(class(AUCformula), class)
 
   for (i in 1:length(lvls)) {
     
-    levelVar <- train[,.v(options[["target"]])] == lvls[i]
+    levelVar <- train[,options[["target"]]] == lvls[i]
     typeData <- cbind(train, levelVar = factor(levelVar))
-    typeData <- typeData[, -which(colnames(typeData) == .v(options[["target"]]))]
+    typeData <- typeData[, -which(colnames(typeData) == options[["target"]])]
     
     score <- .calcAUCScore(AUCformula, train = train, test = test, typeData = typeData, levelVar = levelVar, options = options, ...)
     
-    actual.class <- test[,.v(options[["target"]])] == lvls[i]
+    actual.class <- test[,options[["target"]]] == lvls[i]
     
     if (length(levels(factor(actual.class))) == 2) {
       pred <- ROCR::prediction(score, actual.class)

--- a/R/commonMachineLearningClustering.R
+++ b/R/commonMachineLearningClustering.R
@@ -317,7 +317,7 @@
   startProgressbar(2)
   progressbarTick()
 
-  unique.rows <- which(!duplicated(dataset[, .v(options[["predictors"]])]))
+  unique.rows <- which(!duplicated(dataset[, options[["predictors"]]]))
   if(is.null(jaspResults[["tsneOutput"]])){
     tsne_out <- Rtsne::Rtsne(as.matrix(dataset), perplexity = nrow(dataset) / 4, check_duplicates = FALSE)
     jaspResults[["tsneOutput"]] <- createJaspState(tsne_out)
@@ -515,10 +515,10 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
     clusters <- as.factor(clusterResult[["pred.values"]])
     colorPalette <- colorspace::qualitative_hcl(n = length(unique(clusters)))
 
-    xBreaks <- jaspGraphs::getPrettyAxisBreaks(dataset[[.v(variable)]], min.n = 4)
+    xBreaks <- jaspGraphs::getPrettyAxisBreaks(dataset[[variable]], min.n = 4)
 
     plotData <- data.frame(Cluster = clusters, 
-                           value = dataset[[.v(variable)]])
+                           value = dataset[[variable]])
 
     p <- ggplot2::ggplot(plotData, ggplot2::aes(x = value, fill = Cluster)) +
           ggplot2::geom_density(color = "transparent", alpha = 0.6) +
@@ -618,9 +618,9 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
       clusters <- as.factor(clusterResult[["pred.values"]])
       xBreaks <- as.numeric(levels(clusters))
       
-      clusterMeansData <- aggregate(dataset[[.v(variable)]], list(clusters), mean)
-      clusterSdData <- aggregate(dataset[[.v(variable)]], list(clusters), sd)
-      clusterLengthData <- aggregate(dataset[[.v(variable)]], list(clusters), length)
+      clusterMeansData <- aggregate(dataset[[variable]], list(clusters), mean)
+      clusterSdData <- aggregate(dataset[[variable]], list(clusters), sd)
+      clusterLengthData <- aggregate(dataset[[variable]], list(clusters), length)
 
       plotData <- data.frame(Cluster = clusterMeansData[, 1], 
                             value = clusterMeansData[, 2],

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -20,7 +20,7 @@
     dataset <- .readDataClassificationRegressionAnalyses(dataset, options)
   
   if (length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
-    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- .scaleNumericData(dataset[,.v(c(options[["predictors"]], options[["target"]])), drop = FALSE])
+    dataset[,c(options[["predictors"]], options[["target"]])] <- .scaleNumericData(dataset[,c(options[["predictors"]], options[["target"]]), drop = FALSE])
   
   return(dataset)
 }
@@ -77,7 +77,7 @@
     if (options[["testSetIndicatorVariable"]] %in% predictors)
       jaspBase:::.quitAnalysis(gettextf("The variable '%s' can't be both a predictor and a test set indicator.", options[["testSetIndicatorVariable"]]))
   
-    indicatorVals <- unique(dataset[,.v(options[["testSetIndicatorVariable"]])])
+    indicatorVals <- unique(dataset[,options[["testSetIndicatorVariable"]]])
     if (length(indicatorVals) != 2 || !all(0:1 %in% indicatorVals))
       jaspBase:::.quitAnalysis(gettext("Your test set indicator should be binary, containing only 1 (included in test set) and 0 (excluded from test set)."))
     
@@ -95,7 +95,7 @@
     return()
 
   if (options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator")
-    nTrainAndValid <- length(which(dataset[, .v(options[["testSetIndicatorVariable"]])] == 0))
+    nTrainAndValid <- length(which(dataset[, options[["testSetIndicatorVariable"]]] == 0))
   else
     nTrainAndValid <- ceiling(nrow(dataset) - nrow(dataset)*options[['testDataManual']])
 
@@ -162,8 +162,8 @@
 }
 
 .regressionFormula <- function(options, jaspResults){
-  predictors <- .v(options[["predictors"]])
-  target <- .v(options[["target"]])
+  predictors <- options[["predictors"]]
+  target <- options[["target"]]
   formula <- formula(paste(target, "~", paste(predictors, collapse=" + ")))
   jaspResults[["formula"]] <- createJaspState(formula)
   jaspResults[["formula"]]$dependOn(options = c("predictors", "target"))

--- a/R/mlClassificationBoosting.R
+++ b/R/mlClassificationBoosting.R
@@ -82,7 +82,7 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
   # Split the data into training and test sets
   if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
     # Select observations according to a user-specified indicator (included when indicator = 1)
-    train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+    train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
   } else {
     # Sample a percentage of the total data set
     train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -156,14 +156,14 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
   classificationResult[["formula"]]             <- formula
   classificationResult[["noOfFolds"]]           <- noOfFolds
   classificationResult[["noOfTrees"]]           <- noOfTrees
-  classificationResult[['confTable']]           <- table('Pred' = pred_test, 'Real' = test[,.v(options[["target"]])])
+  classificationResult[['confTable']]           <- table('Pred' = pred_test, 'Real' = test[,options[["target"]]])
   classificationResult[['testAcc']]             <- sum(diag(prop.table(classificationResult[['confTable']])))
   classificationResult[["relInf"]]              <- summary(bfit, plot = FALSE)
   classificationResult[["auc"]]                 <- auc 
   classificationResult[["ntrain"]]              <- nrow(train)
   classificationResult[["ntest"]]               <- nrow(test)
   classificationResult[["testPred"]]            <- pred_test
-  classificationResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  classificationResult[["testReal"]]            <- test[,options[["target"]]]
   classificationResult[["train"]]               <- train
   classificationResult[["test"]]                <- test
   classificationResult[["method"]]              <- ifelse(options[["modelValid"]] == "validationManual", yes = "OOB", no = "")
@@ -171,7 +171,7 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
   classificationResult[["classes"]]             <- predictions
 
   if(options[["modelOpt"]] != "optimizationManual"){
-    classificationResult[["validationConfTable"]] <- table('Pred' = pred_valid, 'Real' = valid[,.v(options[["target"]])])
+    classificationResult[["validationConfTable"]] <- table('Pred' = pred_valid, 'Real' = valid[,options[["target"]]])
     classificationResult[['validAcc']]            <- sum(diag(prop.table(classificationResult[['validationConfTable']])))
     classificationResult[["nvalid"]]              <- nrow(valid)
     classificationResult[["valid"]]               <- valid

--- a/R/mlClassificationKnn.R
+++ b/R/mlClassificationKnn.R
@@ -71,7 +71,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
 	# Split the data into training and test sets
 	if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
 		# Select observations according to a user-specified indicator (included when indicator = 1)
-		train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+		train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
 	} else {
 		# Sample a percentage of the total data set
 		train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -109,10 +109,10 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
       for(i in nnRange){
           kfit_valid <- kknn::kknn(formula = formula, train = train, test = valid, k = i, 
               distance = options[['distanceParameterManual']], kernel = options[['weights']], scale = FALSE)
-          accuracyStore[i] <- sum(diag(prop.table(table(kfit_valid$fitted.values, valid[,.v(options[["target"]])]))))
+          accuracyStore[i] <- sum(diag(prop.table(table(kfit_valid$fitted.values, valid[,options[["target"]]]))))
           kfit_train <- kknn::kknn(formula = formula, train = train, test = train, k = i, 
 				      distance = options[['distanceParameterManual']], kernel = options[['weights']], scale = FALSE)
-			    trainAccuracyStore[i] <- sum(diag(prop.table(table(kfit_train$fitted.values, train[,.v(options[["target"]])]))))
+			    trainAccuracyStore[i] <- sum(diag(prop.table(table(kfit_train$fitted.values, train[,options[["target"]]]))))
           progressbarTick()
       }
 
@@ -181,12 +181,12 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
   classificationResult[["nn"]]                  <- nn
   classificationResult[["weights"]]             <- weights
   classificationResult[["distance"]]            <- distance
-  classificationResult[['confTable']]           <- table('Pred' = kfit_test$fitted.values, 'Real' = test[,.v(options[["target"]])])
+  classificationResult[['confTable']]           <- table('Pred' = kfit_test$fitted.values, 'Real' = test[,options[["target"]]])
   classificationResult[['testAcc']]             <- sum(diag(prop.table(classificationResult[['confTable']])))
   classificationResult[["auc"]]                 <- auc
   classificationResult[["ntrain"]]              <- nrow(train)
   classificationResult[["ntest"]]               <- nrow(test)
-  classificationResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  classificationResult[["testReal"]]            <- test[,options[["target"]]]
   classificationResult[["testPred"]]            <- kfit_test$fitted.values
   classificationResult[["train"]]               <- train 
   classificationResult[["test"]]                <- test 
@@ -197,7 +197,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
     classificationResult[["accuracyStore"]]       <- accuracyStore
     classificationResult[["valid"]]               <- valid
     classificationResult[["nvalid"]]              <- nrow(valid)
-    classificationResult[["validationConfTable"]] <- table('Pred' = kfit_valid$fitted.values, 'Real' = valid[,.v(options[["target"]])])
+    classificationResult[["validationConfTable"]] <- table('Pred' = kfit_valid$fitted.values, 'Real' = valid[,options[["target"]]])
     classificationResult[['validAcc']]            <- sum(diag(prop.table(classificationResult[['validationConfTable']])))
 
     if(options[["modelValid"]] == "validationManual")

--- a/R/mlClassificationLda.R
+++ b/R/mlClassificationLda.R
@@ -84,7 +84,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
              all.target = options$target, observations.amount = '< 5', exitAnalysisIfErrors = TRUE)
   
   # Error Check 2: The target variable should have at least 2 classes
-  if (nlevels(dataset[, .v(options$target)]) < 2){
+  if (nlevels(dataset[, options$target]) < 2){
     jaspBase:::.quitAnalysis(gettext("The target variable should have at least 2 classes."))
   }
   
@@ -99,7 +99,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 	# Split the data into training and test sets
 	if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
 		# Select observations according to a user-specified indicator (included when indicator = 1)
-		train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+		train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
 	} else {
 		# Sample a percentage of the total data set
 		train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -130,11 +130,11 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   classificationResult[["model"]]               <- ldafit
   classificationResult[["method"]]              <- method
   classificationResult[["scaling"]]             <- ldafit[["scaling"]]
-  classificationResult[['confTable']]           <- table('Pred' = pred_test[["class"]], 'Real' = test[,.v(options[["target"]])])
+  classificationResult[['confTable']]           <- table('Pred' = pred_test[["class"]], 'Real' = test[,options[["target"]]])
   classificationResult[['testAcc']]             <- sum(diag(prop.table(classificationResult[['confTable']])))
   classificationResult[["auc"]]                 <- auc
   classificationResult[["testPred"]]            <- pred_test[["class"]]
-  classificationResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  classificationResult[["testReal"]]            <- test[,options[["target"]]]
   classificationResult[["meanTable"]]           <- ldafit[["means"]]
   classificationResult[["relInf"]]              <- summary(ldafit, plot = FALSE)
   classificationResult[["prior"]]               <- ldafit[["prior"]]
@@ -177,7 +177,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   groupmean <- (classificationResult[["model"]]$prior %*% classificationResult[["model"]]$means)
   constants <- (groupmean %*% classificationResult[["scaling"]])
 
-  row <- cbind(pred_level = c(gettext("(Constant)"), .unv(rownames(coefficients))), 
+  row <- cbind(pred_level = c(gettext("(Constant)"), rownames(coefficients)), 
                 as.data.frame(rbind(constants, coefficients)))
     
   coefficientsTable$addRows(row) 
@@ -232,7 +232,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   classificationResult <- jaspResults[["classificationResult"]]$object
   groupMeans <- classificationResult[["meanTable"]]
-  colnames(groupMeans) <- .unv(colnames(groupMeans))
+  colnames(groupMeans) <- colnames(groupMeans)
   
   row <- cbind(target_level = rownames(groupMeans), as.data.frame(groupMeans))  
   meanTable$addRows(row)
@@ -355,10 +355,10 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   
 .ldaDensityplot <- function(classificationResult, options, col){
 
-  target <- classificationResult[["train"]][, .v(options[["target"]])]
+  target <- classificationResult[["train"]][, options[["target"]]]
   lda.fit.scaled <- cbind.data.frame(
     LD = .ldaModelMatrix(classificationResult[["model"]], classificationResult[["train"]]) %*% classificationResult[["scaling"]][, col],
-    V2 = classificationResult[["train"]][,.v(options[["target"]])]
+    V2 = classificationResult[["train"]][,options[["target"]]]
   )
   lda.fit.scaled[["V2"]] <- as.factor(lda.fit.scaled[["V2"]])
 
@@ -395,7 +395,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 .ldaScatterPlot <- function(classificationResult, options, col){
 
   data <- classificationResult[["train"]]
-  target <- data[, .v(options[["target"]])]
+  target <- data[, options[["target"]]]
   model <- classificationResult[["model"]]
 
   pred.values <- stats::predict(model, newdata = data)$x[,c(col, col - 1)]
@@ -435,8 +435,8 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   if(!ready)  return()
 
-  target <- as.numeric(dataset[, .v(options[["target"]])])
-  predictors <- as.matrix(dataset[, .v(options[["predictors"]])])
+  target <- as.numeric(dataset[, options[["target"]]])
+  predictors <- as.matrix(dataset[, options[["predictors"]]])
 
   tryCatch({
     manovaResult <- manova(predictors ~ target)
@@ -477,8 +477,8 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   if(!ready)  return()
 
-  target <- dataset[, .v(options[["target"]])]
-  predictors <- dataset[, .v(options[["predictors"]])]
+  target <- dataset[, options[["target"]]]
+  predictors <- dataset[, options[["predictors"]]]
 
   testLabel <- "Box's M"
   boxSum <- .boxM(predictors, target)
@@ -502,8 +502,8 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   if(!ready)  return()
 
-  target <- dataset[, .v(options[["target"]])]
-  predictors <- dataset[, .v(options[["predictors"]])]
+  target <- dataset[, options[["target"]]]
+  predictors <- dataset[, options[["predictors"]]]
 
   boxSum <- .boxM(predictors, target)
   corPooled <- cor(boxSum[["pooled"]])

--- a/R/mlClassificationRandomForest.R
+++ b/R/mlClassificationRandomForest.R
@@ -76,7 +76,7 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
   # Split the data into training and test sets
   if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
     # Select observations according to a user-specified indicator (included when indicator = 1)
-    train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+    train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
   } else {
     # Sample a percentage of the total data set
     train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -92,10 +92,10 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
     train                   <- trainAndValid
     test                    <- dataset[-train.index, ]
 
-    train_predictors        <- train[, .v(options[["predictors"]])]
-    train_target            <- train[, .v(options[["target"]])]
-    test_predictors         <- test[, .v(options[["predictors"]])]
-    test_target             <- test[, .v(options[["target"]])]
+    train_predictors        <- train[, options[["predictors"]]]
+    train_target            <- train[, options[["target"]]]
+    test_predictors         <- test[, options[["predictors"]]]
+    test_target             <- test[, options[["target"]]]
 
     rfit_test <- randomForest::randomForest(x = train_predictors, y = train_target, xtest = test_predictors, ytest = test_target,
                                             ntree = options[["noOfTrees"]], mtry = noOfPredictors,
@@ -110,12 +110,12 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
     valid                   <- trainAndValid[valid.index, ]
     train                   <- trainAndValid[-valid.index, ]
 
-    train_predictors <- train[, .v(options[["predictors"]])]
-    train_target <- train[, .v(options[["target"]])]
-    valid_predictors <- valid[, .v(options[["predictors"]])]
-    valid_target <- valid[, .v(options[["target"]])]
-    test_predictors <- test[, .v(options[["predictors"]])]
-    test_target <- test[, .v(options[["target"]])]
+    train_predictors <- train[, options[["predictors"]]]
+    train_target <- train[, options[["target"]]]
+    valid_predictors <- valid[, options[["predictors"]]]
+    valid_target <- valid[, options[["target"]]]
+    test_predictors <- test[, options[["predictors"]]]
+    test_target <- test[, options[["target"]]]
 
     rfit_valid <- randomForest::randomForest(x = train_predictors, y = train_target, xtest = valid_predictors, ytest = valid_target,
                                         ntree = options[["maxTrees"]], mtry = noOfPredictors,
@@ -152,11 +152,11 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
   classificationResult[["noOfTrees"]]           <- noOfTrees
   classificationResult[["predPerSplit"]]        <- noOfPredictors
   classificationResult[["bagFrac"]]             <- ceiling(options[["bagFrac"]]*nrow(dataset))
-  classificationResult[['confTable']]           <- table('Pred' = rfit_test$test[["predicted"]], 'Real' = test[,.v(options[["target"]])])
+  classificationResult[['confTable']]           <- table('Pred' = rfit_test$test[["predicted"]], 'Real' = test[,options[["target"]]])
   classificationResult[['testAcc']]             <- sum(diag(prop.table(classificationResult[['confTable']])))
   classificationResult[["auc"]]                 <- auc
   classificationResult[["testPred"]]            <- rfit_test$test[["predicted"]]
-  classificationResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  classificationResult[["testReal"]]            <- test[,options[["target"]]]
   classificationResult[["ntrain"]]              <- nrow(train)
   classificationResult[["ntest"]]               <- nrow(test)
   classificationResult[["train"]]               <- train
@@ -164,13 +164,13 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
   classificationResult[["testIndicatorColumn"]] <- testIndicatorColumn
   classificationResult[["classes"]]             <- predictions
   classificationResult[["oobAccuracy"]]         <- 1 - rfit_test$err.rate[length(rfit_test$err.rate)]
-  classificationResult[["varImp"]]              <- plyr::arrange(data.frame(Variable = .unv(as.factor(names(rfit_test$importance[,1]))),
+  classificationResult[["varImp"]]              <- plyr::arrange(data.frame(Variable = as.factor(names(rfit_test$importance[,1])),
                                                                             MeanIncrMSE  = rfit_test$importance[, 1],
                                                                             TotalDecrNodeImp = rfit_test$importance[, 2]), -TotalDecrNodeImp)
 
   if(options[["modelOpt"]] != "optimizationManual"){
     classificationResult[["rfit_valid"]]          <- rfit_valid
-    classificationResult[["validationConfTable"]] <- table('Pred' = rfit_valid$test[["predicted"]], 'Real' = valid[,.v(options[["target"]])])
+    classificationResult[["validationConfTable"]] <- table('Pred' = rfit_valid$test[["predicted"]], 'Real' = valid[,options[["target"]]])
     classificationResult[['validAcc']]            <- sum(diag(prop.table(classificationResult[['validationConfTable']])))
     classificationResult[["nvalid"]]              <- nrow(valid)
     classificationResult[["valid"]]               <- valid

--- a/R/mlClusteringDensityBased.R
+++ b/R/mlClusteringDensityBased.R
@@ -56,29 +56,29 @@ mlClusteringDensityBased <- function(jaspResults, dataset, options, ...) {
 .densityBasedClustering <- function(dataset, options, jaspResults){
  
   if (options[["distance"]] == "Correlated densities") {
-    dfit <- dbscan::dbscan(as.dist(1-cor(t(as.data.frame(dataset[, .v(options[["predictors"]])])), method = "pearson")), eps = options[['eps']], minPts = options[['minPts']])
+    dfit <- dbscan::dbscan(as.dist(1-cor(t(as.data.frame(dataset[, options[["predictors"]]])), method = "pearson")), eps = options[['eps']], minPts = options[['minPts']])
   } else {
-    dfit <- dbscan::dbscan(as.data.frame(dataset[, .v(options[["predictors"]])]), eps = options[['eps']], minPts = options[['minPts']])
+    dfit <- dbscan::dbscan(as.data.frame(dataset[, options[["predictors"]]]), eps = options[['eps']], minPts = options[['minPts']])
   }
 
   noisePoints <- length(dfit$cluster[dfit$cluster == 0])
   clusters <- ifelse(noisePoints > 0, yes = length(table(dfit$cluster)) - 1, no = length(table(dfit$cluster)))
 
-  m <- dim(as.data.frame(dataset[, .v(options[["predictors"]])]))[2]
+  m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
   
   wss <- numeric(clusters)
   for(i in 1:clusters) {
     if (m == 1) {
-      wss[i] <- .ss(dataset[, .v(options[["predictors"]])][dfit$cluster == i])
+      wss[i] <- .ss(dataset[, options[["predictors"]]][dfit$cluster == i])
     } else {
-      wss[i] <- .ss(dataset[, .v(options[["predictors"]])][dfit$cluster == i,])
+      wss[i] <- .ss(dataset[, options[["predictors"]]][dfit$cluster == i,])
     }
   }
 
   if(noisePoints > 0) {
-    tss <- .tss(dist(dataset[, .v(options[["predictors"]])][dfit$cluster != 0, ]))
+    tss <- .tss(dist(dataset[, options[["predictors"]]][dfit$cluster != 0, ]))
   } else {
-    tss <- .tss(dist(dataset[, .v(options[["predictors"]])]))
+    tss <- .tss(dist(dataset[, options[["predictors"]]]))
   }
 
   pred.values <- dfit$cluster
@@ -105,9 +105,9 @@ mlClusteringDensityBased <- function(jaspResults, dataset, options, ...) {
   
   if (oneMark == 0 && zeroMark == 0){
     if(options[["distance"]] == "Normal densities"){
-      silhouettes <- summary(cluster::silhouette(dfit$cluster, dist(dataset[, .v(options[["predictors"]])])))
+      silhouettes <- summary(cluster::silhouette(dfit$cluster, dist(dataset[, options[["predictors"]]])))
     } else if(options[["distance"]] == "Correlated densities"){
-      silhouettes <- summary(cluster::silhouette(dfit$cluster, as.dist(1-cor(t(dataset[, .v(options[["predictors"]])])))))
+      silhouettes <- summary(cluster::silhouette(dfit$cluster, as.dist(1-cor(t(dataset[, options[["predictors"]]])))))
     }
   } else {
     silhouettes <- list("avg.width" = 0, "clus.avg.widths" = rep(0, max(1, clusters)))
@@ -146,8 +146,8 @@ mlClusteringDensityBased <- function(jaspResults, dataset, options, ...) {
 
   if(!ready) return()
 
-  unique.rows <- which(!duplicated(dataset[, .v(options[["predictors"]])]))
-  data <- dataset[unique.rows, .v(options[["predictors"]])]
+  unique.rows <- which(!duplicated(dataset[, options[["predictors"]]]))
+  data <- dataset[unique.rows, options[["predictors"]]]
   if(options[["distance"]] == "Correlated densities"){
     knnDist <- dbscan::kNNdist(as.dist(1-cor(t(as.data.frame(data)), method = "pearson")), k = options[['minPts']])
   } else {

--- a/R/mlClusteringFuzzyCMeans.R
+++ b/R/mlClusteringFuzzyCMeans.R
@@ -57,7 +57,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
   
   if(options[["modelOpt"]] == "validationManual"){
       
-    cfit <- e1071::cmeans(dataset[, .v(options[["predictors"]])],
+    cfit <- e1071::cmeans(dataset[, options[["predictors"]]],
                             centers = options[['noOfClusters']],
                             iter.max = options[['noOfIterations']],
                             m = options[["m"]], 
@@ -76,17 +76,17 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
     startProgressbar(length(clusterRange))
 
     for (i in clusterRange) {
-      cfit_tmp <- e1071::cmeans(dataset[, .v(options[["predictors"]])],
+      cfit_tmp <- e1071::cmeans(dataset[, options[["predictors"]]],
                               centers = i,
                               iter.max = options[['noOfIterations']],
                               m = options[["m"]],
                               method = "ufcl") # method = "cmeans" can yield a number of clusters that is not equal to the requested number
-      silh <- summary(cluster::silhouette(cfit_tmp$cluster, dist(dataset[, .v(options[["predictors"]])])))
+      silh <- summary(cluster::silhouette(cfit_tmp$cluster, dist(dataset[, options[["predictors"]]])))
       avg_silh[i - 1] <- silh[["avg.width"]]
 
       v_tmp <- cfit_tmp$centers
       clabels_tmp <- cfit_tmp$cluster
-      csumsqrs_tmp <- .sumsqr(dataset[, .v(options[["predictors"]])], v_tmp, clabels_tmp) 
+      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp) 
       wssStore[i - 1] <- csumsqrs_tmp$tot.within.ss
 
       m <- ncol(cfit_tmp$centers)
@@ -104,7 +104,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
   
-  cfit <- e1071::cmeans(dataset[, .v(options[["predictors"]])],
+  cfit <- e1071::cmeans(dataset[, options[["predictors"]]],
                           centers = clusters,
                           iter.max = options[['noOfIterations']],
                           m = options[["m"]])
@@ -113,7 +113,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
 
   v <- cfit$centers
   clabels <- cfit$cluster
-  csumsqrs <- .sumsqr(dataset[, .v(options[["predictors"]])], v, clabels)
+  csumsqrs <- .sumsqr(dataset[, options[["predictors"]]], v, clabels)
 
   pred.values <- cfit$cluster
   clusters <- clusters
@@ -130,7 +130,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
   aic <- D + 2*m*k
   bic <- D + log(n)*m*k
 
-  silhouettes <- summary(cluster::silhouette(cfit$cluster, dist(dataset[, .v(options[["predictors"]])])))
+  silhouettes <- summary(cluster::silhouette(cfit$cluster, dist(dataset[, options[["predictors"]]])))
   Silh_score <- silhouettes[["avg.width"]]
   silh_scores <- silhouettes[["clus.avg.widths"]]
 

--- a/R/mlClusteringHierarchical.R
+++ b/R/mlClusteringHierarchical.R
@@ -61,11 +61,11 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
   if(options[["modelOpt"]] == "validationManual"){
         
     if (options[["distance"]] == "Pearson correlation") {
-      distances <- as.dist(1 - cor(t(dataset[, .v(options[["predictors"]])]), method = "pearson"))
+      distances <- as.dist(1 - cor(t(dataset[, options[["predictors"]]]), method = "pearson"))
       distances[is.na(distances)] <- 1 # We impute the missing correlations with a 1, as 1 - 1 = 0
       hfit <- cutree(hclust(distances, method = options[["linkage"]]), k = options[['noOfClusters']])
     } else {
-      distances <- dist(dataset[, .v(options[["predictors"]])])
+      distances <- dist(dataset[, options[["predictors"]]])
       hfit <- cutree(hclust(distances, method = options[["linkage"]]), k = options[['noOfClusters']])
     }
 
@@ -84,24 +84,24 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
     for (i in clusterRange){
 
       if(options[["distance"]] == "Pearson correlation") {
-        distances <- as.dist(1 - cor(t(dataset[, .v(options[["predictors"]])]), method = "pearson"))
+        distances <- as.dist(1 - cor(t(dataset[, options[["predictors"]]]), method = "pearson"))
         distances[is.na(distances)] <- 1 # We impute the missing correlations with a 1, as 1 - 1 = 0
         hfit_tmp <- cutree(hclust(distances, method = options[["linkage"]]), k = i)
       } else {
-        distances <- dist(dataset[, .v(options[["predictors"]])])
+        distances <- dist(dataset[, options[["predictors"]]])
         hfit_tmp <- cutree(hclust(distances, method = options[["linkage"]]), k = i)
       }
       silh <- summary(cluster::silhouette(hfit_tmp, distances))
       avg_silh[i - 1] <- silh[["avg.width"]]
 
-      m <- dim(as.data.frame(dataset[, .v(options[["predictors"]])]))[2]
+      m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
 
       wss <- numeric(length(table(hfit_tmp)))
       for (j in 1:length(table(hfit_tmp))) {
         if (m == 1) {
-          wss[j] <- .ss(dataset[, .v(options[["predictors"]])][hfit_tmp == j])
+          wss[j] <- .ss(dataset[, options[["predictors"]]][hfit_tmp == j])
         } else {
-          wss[j] <- .ss(dataset[, .v(options[["predictors"]])][hfit_tmp == j,])
+          wss[j] <- .ss(dataset[, options[["predictors"]]][hfit_tmp == j,])
         }
       }
       wssStore[i - 1] <- sum(wss)
@@ -130,14 +130,14 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
   clusters <- clusters
   size <- as.data.frame(table(hfit))[,2]
 
-  m <- dim(as.data.frame(dataset[, .v(options[["predictors"]])]))[2]
+  m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
 
   wss <- numeric(length(table(hfit)))
   for (j in 1:length(table(hfit))) {
     if (m == 1) {
-      wss[j] <- .ss(dataset[, .v(options[["predictors"]])][hfit == j])
+      wss[j] <- .ss(dataset[, options[["predictors"]]][hfit == j])
     } else {
-      wss[j] <- .ss(dataset[, .v(options[["predictors"]])][hfit == j,])
+      wss[j] <- .ss(dataset[, options[["predictors"]]][hfit == j,])
     }
   }
 
@@ -158,7 +158,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
   clusterResult[["N"]] <- nrow(dataset)
   clusterResult[['size']] <- size
   clusterResult[['WSS']] <- wss
-  clusterResult[['TSS']] <- .tss(dist(dataset[, .v(options[["predictors"]])]))
+  clusterResult[['TSS']] <- .tss(dist(dataset[, options[["predictors"]]]))
   clusterResult[['BSS']] <- clusterResult[['TSS']] - sum(clusterResult[['WSS']])
   clusterResult[['AIC']] <- aic
   clusterResult[['BIC']] <- bic
@@ -192,8 +192,8 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
 
   if(options[["seedBox"]])  set.seed(options[["seed"]])
 
-  unique.rows <- which(!duplicated(dataset[, .v(options[["predictors"]])]))
-  data <- dataset[unique.rows, .v(options[["predictors"]])]
+  unique.rows <- which(!duplicated(dataset[, options[["predictors"]]]))
+  data <- dataset[unique.rows, options[["predictors"]]]
 
   if(options[["distance"]] == "Pearson correlation") {
     hc <- hclust(as.dist(1-cor(t(data), method="pearson")), method = options[["linkage"]])

--- a/R/mlClusteringKMeans.R
+++ b/R/mlClusteringKMeans.R
@@ -57,7 +57,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
 
   if(options[["modelOpt"]] == "validationManual"){
     
-    kfit <- kmeans(dataset[, .v(options[["predictors"]])],
+    kfit <- kmeans(dataset[, options[["predictors"]]],
                    centers = options[['noOfClusters']],
                    iter.max = options[['noOfIterations']],
                    nstart = options[['noOfRandomSets']],
@@ -76,17 +76,17 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
     startProgressbar(length(clusterRange))
 
     for (i in clusterRange) {
-      kfit_tmp <- kmeans(dataset[, .v(options[["predictors"]])],
+      kfit_tmp <- kmeans(dataset[, options[["predictors"]]],
                    centers = i,
                    iter.max = options[['noOfIterations']],
                    nstart = options[['noOfRandomSets']],
                    algorithm = options[['algorithm']])
-      silh <- summary(cluster::silhouette(kfit_tmp$cluster, dist(dataset[, .v(options[["predictors"]])])))
+      silh <- summary(cluster::silhouette(kfit_tmp$cluster, dist(dataset[, options[["predictors"]]])))
       avg_silh[i - 1] <- silh[["avg.width"]]
 
       v_tmp <- kfit_tmp$centers
       clabels_tmp <- kfit_tmp$cluster
-      csumsqrs_tmp <- .sumsqr(dataset[, .v(options[["predictors"]])], v_tmp, clabels_tmp) 
+      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp) 
       wssStore[i - 1] <- csumsqrs_tmp$tot.within.ss
 
       m <- ncol(kfit_tmp$centers)
@@ -104,7 +104,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
   
-  kfit <- kmeans(dataset[, .v(options[["predictors"]])],
+  kfit <- kmeans(dataset[, options[["predictors"]]],
                  centers = clusters,
                  iter.max = options[['noOfIterations']],
                  nstart = options[['noOfRandomSets']],
@@ -127,7 +127,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
   aic <- D + 2*m*k
   bic <- D + log(n)*m*k
 
-  silhouettes <- summary(cluster::silhouette(kfit$cluster, dist(dataset[, .v(options[["predictors"]])])))
+  silhouettes <- summary(cluster::silhouette(kfit$cluster, dist(dataset[, options[["predictors"]]])))
   Silh_score <- silhouettes[["avg.width"]]
   silh_scores <- silhouettes[["clus.avg.widths"]]
 

--- a/R/mlClusteringRandomForest.R
+++ b/R/mlClusteringRandomForest.R
@@ -201,7 +201,7 @@ if(options[["modelOpt"]] == "validationManual"){
   fit <- clusterResult[["fit"]]
   varImp <- fit[["importance"]]
   ord <- order(varImp, decreasing = TRUE)
-  name <- rownames(varImp[ord])
+  name <- rownames(varImp)[ord]
   values <- as.numeric(varImp[ord])
   
   # Add data per column

--- a/R/mlClusteringRandomForest.R
+++ b/R/mlClusteringRandomForest.R
@@ -60,7 +60,7 @@ mlClusteringRandomForest <- function(jaspResults, dataset, options, ...) {
 
 if(options[["modelOpt"]] == "validationManual"){
       
-    rfit <- randomForest::randomForest(x = dataset[, .v(options[["predictors"]])], 
+    rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
 										y = NULL, 
 										ntree = options[["noOfTrees"]], 
 										proximity = TRUE, 
@@ -78,7 +78,7 @@ if(options[["modelOpt"]] == "validationManual"){
 
     startProgressbar(length(clusterRange))
 
-	rfit_tmp <- randomForest::randomForest(x = dataset[, .v(options[["predictors"]])], 
+	rfit_tmp <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
 									y = NULL, 
 									ntree = options[["noOfTrees"]], 
 									proximity = TRUE, 
@@ -88,17 +88,17 @@ if(options[["modelOpt"]] == "validationManual"){
     for (i in clusterRange) {
 
   	  pred.values <- cutree(hrfit_tmp, k = i)
-      silh <- summary(cluster::silhouette(pred.values, dist(dataset[, .v(options[["predictors"]])])))
+      silh <- summary(cluster::silhouette(pred.values, dist(dataset[, options[["predictors"]]])))
       avg_silh[i - 1] <- silh[["avg.width"]]
 
-	  m <- dim(as.data.frame(dataset[, .v(options[["predictors"]])]))[2]
+	  m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
   
     wss_tmp <- numeric(i)
     for(j in 1:i) {
       if (m == 1) {
-        wss_tmp[j] <- .ss(dataset[, .v(options[["predictors"]])][pred.values == j])
+        wss_tmp[j] <- .ss(dataset[, options[["predictors"]]][pred.values == j])
       } else {
-        wss_tmp[j] <- .ss(dataset[, .v(options[["predictors"]])][pred.values == j,])
+        wss_tmp[j] <- .ss(dataset[, options[["predictors"]]][pred.values == j,])
       }
     }
 
@@ -118,7 +118,7 @@ if(options[["modelOpt"]] == "validationManual"){
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
 
-	rfit <- randomForest::randomForest(x = dataset[, .v(options[["predictors"]])], 
+	rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
 										y = NULL, 
 										ntree = options[["noOfTrees"]], 
 										proximity = TRUE, 
@@ -132,18 +132,18 @@ if(options[["modelOpt"]] == "validationManual"){
   clusters <- clusters
   size <- as.numeric(table(pred.values))
 
-  m <- dim(as.data.frame(dataset[, .v(options[["predictors"]])]))[2]
+  m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
   
   wss <- numeric(clusters)
   for(i in 1:clusters) {
     if (m == 1) {
-      wss[i] <- .ss(dataset[, .v(options[["predictors"]])][pred.values == i])
+      wss[i] <- .ss(dataset[, options[["predictors"]]][pred.values == i])
     } else {
-      wss[i] <- .ss(dataset[, .v(options[["predictors"]])][pred.values == i,])
+      wss[i] <- .ss(dataset[, options[["predictors"]]][pred.values == i,])
     }
   }
 
-  tss <- .tss(dist(dataset[, .v(options[["predictors"]])]))
+  tss <- .tss(dist(dataset[, options[["predictors"]]]))
 
   n <- length(pred.values)
   k <- clusters
@@ -151,7 +151,7 @@ if(options[["modelOpt"]] == "validationManual"){
   aic <- D + 2*m*k
   bic <- D + log(n)*m*k
 
-  silhouettes <- summary(cluster::silhouette(pred.values, dist(dataset[, .v(options[["predictors"]])])))
+  silhouettes <- summary(cluster::silhouette(pred.values, dist(dataset[, options[["predictors"]]])))
   Silh_score <- silhouettes[["avg.width"]]
   silh_scores <- silhouettes[["clus.avg.widths"]]
 
@@ -201,7 +201,7 @@ if(options[["modelOpt"]] == "validationManual"){
   fit <- clusterResult[["fit"]]
   varImp <- fit[["importance"]]
   ord <- order(varImp, decreasing = TRUE)
-  name <- .unv(rownames(varImp)[ord])
+  name <- rownames(varImp[ord])
   values <- as.numeric(varImp[ord])
   
   # Add data per column

--- a/R/mlRegressionBoosting.R
+++ b/R/mlRegressionBoosting.R
@@ -70,7 +70,7 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
   # Split the data into training and test sets
   if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
     # Select observations according to a user-specified indicator (included when indicator = 1)
-    train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+    train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
   } else {
     # Sample a percentage of the total data set
     train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -141,19 +141,19 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
   regressionResult[["noOfFolds"]]   <- noOfFolds
   regressionResult[["noOfTrees"]]   <- noOfTrees
   regressionResult[["method"]]      <- ifelse(options[["modelValid"]] == "validationManual", yes = "OOB", no = "")
-  regressionResult[['testMSE']]     <- mean((pred_test - test[,.v(options[["target"]])])^2)
+  regressionResult[['testMSE']]     <- mean((pred_test - test[,options[["target"]]])^2)
   regressionResult[["relInf"]]      <- summary(bfit, plot = FALSE)
   regressionResult[["ntrain"]]      <- nrow(train)
   regressionResult[["ntest"]]       <- nrow(test)
   regressionResult[["testPred"]]    <- pred_test
-  regressionResult[["testReal"]]    <- test[,.v(options[["target"]])]
+  regressionResult[["testReal"]]    <- test[,options[["target"]]]
   regressionResult[["train"]]       <- train
   regressionResult[["test"]]        <- test
   regressionResult[["testIndicatorColumn"]] <- testIndicatorColumn
   regressionResult[["values"]]      <- predictions
 
   if(options[["modelOpt"]] != "optimizationManual"){
-    regressionResult[['validMSE']]    <- mean((pred_valid - valid[,.v(options[["target"]])])^2)
+    regressionResult[['validMSE']]    <- mean((pred_valid - valid[,options[["target"]]])^2)
     regressionResult[["nvalid"]]      <- nrow(valid)
     regressionResult[["valid"]]       <- valid
   }
@@ -183,7 +183,7 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
                           "classification" = jaspResults[["classificationResult"]]$object,
                           "regression" = jaspResults[["regressionResult"]]$object)
 
-  classBoostRelInfTable[["predictor"]]  <- .unv(as.character(result[["relInf"]]$var))
+  classBoostRelInfTable[["predictor"]]  <- as.character(result[["relInf"]]$var)
   classBoostRelInfTable[["relIn"]]  <- result[["relInf"]]$rel.inf
 }
 
@@ -208,7 +208,7 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
   oobDev <- data.frame(trees = 1:result[["model"]]$n.trees, oobImprove = result[["model"]]$oobag.improve, type = gettext("Training set"))
 
   if(purpose == "classification"){
-    if (nlevels(result[["test"]][,.v(options[["target"]])]) > 2L) {
+    if (nlevels(result[["test"]][,options[["target"]]]) > 2L) {
       ylab <- gettextf("OOB Change in %s Multinomial Deviance", "\n")
     } else {
       ylab <- gettextf("OOB Change in %s Binomial Deviance", "\n")
@@ -269,7 +269,7 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
   )
 
   if(purpose == "classification"){
-    if (nlevels(result[["test"]][,.v(options[["target"]])]) > 2L) {
+    if (nlevels(result[["test"]][,options[["target"]]]) > 2L) {
       ylab <- gettext("Multinomial Deviance")
     } else {
       ylab <- gettext("Binomial Deviance")
@@ -323,7 +323,7 @@ mlRegressionBoosting <- function(jaspResults, dataset, options, ...) {
                         "classification" = jaspResults[["classificationResult"]]$object,
                         "regression" = jaspResults[["regressionResult"]]$object)
 
-  p <- ggplot2::ggplot(result[["relInf"]], ggplot2::aes(x = reorder(.unv(as.factor(var)), rel.inf), y = rel.inf)) +
+  p <- ggplot2::ggplot(result[["relInf"]], ggplot2::aes(x = reorder(as.factor(var), rel.inf), y = rel.inf)) +
         ggplot2::geom_bar(stat = "identity", fill = "gray", col = "black", size = .3) +
         ggplot2::labs(x = "", y = gettext("Relative Influence"))
   p <- jaspGraphs::themeJasp(p, horizontal = TRUE, xAxis = FALSE) + ggplot2::theme(axis.ticks.y = ggplot2::element_blank())

--- a/R/mlRegressionKnn.R
+++ b/R/mlRegressionKnn.R
@@ -59,7 +59,7 @@ mlRegressionKnn <- function(jaspResults, dataset, options, state=NULL) {
 	# Split the data into training and test sets
 	if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
 		# Select observations according to a user-specified indicator (included when indicator = 1)
-		train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+		train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
 	} else {
 		# Sample a percentage of the total data set
 		train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -97,10 +97,10 @@ mlRegressionKnn <- function(jaspResults, dataset, options, state=NULL) {
 				
 				kfit_valid <- kknn::kknn(formula = formula, train = train, test = valid, k = i, 
 					distance = distance, kernel = weights, scale = FALSE)
-				errorStore[i] <- mean( (kfit_valid$fitted.values -  valid[,.v(options[["target"]])])^2 )
+				errorStore[i] <- mean( (kfit_valid$fitted.values -  valid[,options[["target"]]])^2 )
 				kfit_train <- kknn::kknn(formula = formula, train = train, test = train, k = i, 
 							distance = distance, kernel = weights, scale = FALSE)
-				trainErrorStore[i] <- mean( (kfit_train$fitted.values -  train[,.v(options[["target"]])])^2 )
+				trainErrorStore[i] <- mean( (kfit_train$fitted.values -  train[,options[["target"]]])^2 )
 				progressbarTick()
 
 			}
@@ -167,17 +167,17 @@ mlRegressionKnn <- function(jaspResults, dataset, options, state=NULL) {
 	regressionResult[["nn"]]          	<- nn
 	regressionResult[["weights"]]     	<- weights
 	regressionResult[["distance"]]    	<- distance
-	regressionResult[['testMSE']]     	<- mean( (kfit_test$fitted.values -  test[,.v(options[["target"]])])^2 )
+	regressionResult[['testMSE']]     	<- mean( (kfit_test$fitted.values -  test[,options[["target"]]])^2 )
 	regressionResult[["ntrain"]]      	<- nrow(train)
 	regressionResult[["ntest"]]       	<- nrow(test)
-	regressionResult[["testReal"]]	  	<- test[, .v(options[["target"]])]
+	regressionResult[["testReal"]]	  	<- test[, options[["target"]]]
 	regressionResult[["testPred"]]		<- kfit_test$fitted.values
 	regressionResult[["testIndicatorColumn"]] <- testIndicatorColumn
 	regressionResult[["values"]] 		<- predictions
 
 	if(options[["modelOpt"]] != "optimizationManual"){
 		regressionResult[["accuracyStore"]] <- errorStore
-		regressionResult[['validMSE']]    <- mean( (kfit_valid$fitted.values -  valid[,.v(options[["target"]])])^2 )
+		regressionResult[['validMSE']]    <- mean( (kfit_valid$fitted.values -  valid[,options[["target"]]])^2 )
 		regressionResult[["nvalid"]]      <- nrow(valid)
 		regressionResult[["valid"]]       <- valid
 

--- a/R/mlRegressionRandomForest.R
+++ b/R/mlRegressionRandomForest.R
@@ -64,7 +64,7 @@ mlRegressionRandomForest <- function(jaspResults, dataset, options, ...) {
   # Split the data into training and test sets
   if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
     # Select observations according to a user-specified indicator (included when indicator = 1)
-    train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+    train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
   } else {
     # Sample a percentage of the total data set
     train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -80,10 +80,10 @@ mlRegressionRandomForest <- function(jaspResults, dataset, options, ...) {
     train                   <- trainAndValid
     test                    <- dataset[-train.index, ]
 
-    train_predictors <- train[, .v(options[["predictors"]])]
-    train_target <- train[, .v(options[["target"]])]
-    test_predictors <- test[, .v(options[["predictors"]])]
-    test_target <- test[, .v(options[["target"]])]
+    train_predictors <- train[, options[["predictors"]]]
+    train_target <- train[, options[["target"]]]
+    test_predictors <- test[, options[["predictors"]]]
+    test_target <- test[, options[["target"]]]
 
     rfit_test <- randomForest::randomForest(x = train_predictors, y = train_target, xtest = test_predictors, ytest = test_target,
                                             ntree = options[["noOfTrees"]], mtry = noOfPredictors,
@@ -98,12 +98,12 @@ mlRegressionRandomForest <- function(jaspResults, dataset, options, ...) {
     valid                   <- trainAndValid[valid.index, ]
     train                   <- trainAndValid[-valid.index, ]
 
-    train_predictors <- train[, .v(options[["predictors"]])]
-    train_target <- train[, .v(options[["target"]])]
-    valid_predictors <- valid[, .v(options[["predictors"]])]
-    valid_target <- valid[, .v(options[["target"]])]
-    test_predictors <- test[, .v(options[["predictors"]])]
-    test_target <- test[, .v(options[["target"]])]
+    train_predictors <- train[, options[["predictors"]]]
+    train_target <- train[, options[["target"]]]
+    valid_predictors <- valid[, options[["predictors"]]]
+    valid_target <- valid[, options[["target"]]]
+    test_predictors <- test[, options[["predictors"]]]
+    test_target <- test[, options[["target"]]]
 
     rfit_valid <- randomForest::randomForest(x = train_predictors, y = train_target, xtest = valid_predictors, ytest = valid_target,
                                     ntree = options[["maxTrees"]], mtry = noOfPredictors,
@@ -136,9 +136,9 @@ mlRegressionRandomForest <- function(jaspResults, dataset, options, ...) {
   regressionResult[["noOfTrees"]]           <- noOfTrees
   regressionResult[["predPerSplit"]]        <- noOfPredictors
   regressionResult[["bagFrac"]]             <- ceiling(options[["bagFrac"]]*nrow(dataset))
-  regressionResult[["testMSE"]]             <- mean((rfit_test$test[["predicted"]] - test[,.v(options[["target"]])])^2)
+  regressionResult[["testMSE"]]             <- mean((rfit_test$test[["predicted"]] - test[,options[["target"]]])^2)
   regressionResult[["testPred"]]            <- rfit_test$test[["predicted"]]
-  regressionResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  regressionResult[["testReal"]]            <- test[,options[["target"]]]
   regressionResult[["oobError"]]            <- rfit_test$mse[length(rfit_test$mse)]
   regressionResult[["ntrain"]]              <- nrow(train)
   regressionResult[["ntest"]]               <- nrow(test)
@@ -147,13 +147,13 @@ mlRegressionRandomForest <- function(jaspResults, dataset, options, ...) {
   regressionResult[["testIndicatorColumn"]] <- testIndicatorColumn
   regressionResult[["values"]]              <- predictions
   regressionResult[["varImp"]]              <- plyr::arrange(data.frame(
-                                                            Variable = .unv(as.factor(names(rfit_test$importance[,1]))),
+                                                            Variable = as.factor(names(rfit_test$importance[,1])),
                                                             MeanIncrMSE = rfit_test$importance[, 1],
                                                             TotalDecrNodeImp = rfit_test$importance[, 2]
                                                           ), -TotalDecrNodeImp)
 
   if(options[["modelOpt"]] != "optimizationManual"){
-    regressionResult[['validMSE']]    <- mean((rfit_valid$test[["predicted"]] - valid[,.v(options[["target"]])])^2)
+    regressionResult[['validMSE']]    <- mean((rfit_valid$test[["predicted"]] - valid[,options[["target"]]])^2)
     regressionResult[["nvalid"]]      <- nrow(valid)
     regressionResult[["valid"]]       <- valid
     regressionResult[["rfit_valid"]]  <- rfit_valid

--- a/R/mlRegressionRegularized.R
+++ b/R/mlRegressionRegularized.R
@@ -235,7 +235,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     labs <- rownames(coefTab)[-1]
     values <- as.numeric(coefTab)[-1]
   } else {
-    labs <- c("(Intercept)", rownames(coefTab[-1]))
+    labs <- c("(Intercept)", rownames(coefTab)[-1])
     values <- as.numeric(coefTab)
   }
   

--- a/R/mlRegressionRegularized.R
+++ b/R/mlRegressionRegularized.R
@@ -74,7 +74,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   }
   
   if(length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
-    dataset[,.v(c(options[["predictors"]], options[["target"]]))] <- .scaleNumericData(dataset[,.v(c(options[["predictors"]], options[["target"]])), drop = FALSE])
+    dataset[,c(options[["predictors"]], options[["target"]])] <- .scaleNumericData(dataset[,c(options[["predictors"]], options[["target"]]), drop = FALSE])
   
   return(dataset)
 }
@@ -97,7 +97,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   }
 
   if(options[["weights"]] != ""){
-    weights <- dataset[, .v(options[["weights"]])]
+    weights <- dataset[, options[["weights"]]]
   } else {
     weights <- rep(1, nrow(dataset))
   }
@@ -105,7 +105,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   # Split the data into training and test sets
 	if(options[["holdoutData"]] == "testSetIndicator" && options[["testSetIndicatorVariable"]] != ""){
     # Select observations according to a user-specified indicator (included when indicator = 1)
-		train.index             <- which(dataset[,.v(options[["testSetIndicatorVariable"]])] == 0)
+		train.index             <- which(dataset[,options[["testSetIndicatorVariable"]]] == 0)
 	} else {
     # Sample a percentage of the total data set
 		train.index             <- sample.int(nrow(dataset), size = ceiling( (1 - options[['testDataManual']]) * nrow(dataset)))
@@ -123,10 +123,10 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
 
     weights_train           <- weights[train.index]
 
-    train_pred <- as.matrix(train[,.v(options[["predictors"]])])
-    train_target <- train[, .v(options[["target"]])]
-    test_pred <- as.matrix(test[,.v(options[["predictors"]])])
-    test_target <- test[, .v(options[["target"]])]
+    train_pred <- as.matrix(train[,options[["predictors"]]])
+    train_target <- train[, options[["target"]]]
+    test_pred <- as.matrix(test[,options[["predictors"]]])
+    test_target <- test[, options[["target"]]]
 
     regfit_train <- glmnet::cv.glmnet(x = train_pred, y = train_target, nfolds = 10, type.measure = "deviance",
                                 family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha, 
@@ -148,12 +148,12 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     weights_train           <- weights[train.index]
     weights_train           <- weights_train[-valid.index]
 
-    train_pred <- as.matrix(train[,.v(options[["predictors"]])])
-    train_target <- train[, .v(options[["target"]])]
-    valid_pred <- as.matrix(valid[,.v(options[["predictors"]])])
-    valid_target <- valid[, .v(options[["target"]])]
-    test_pred <- as.matrix(test[,.v(options[["predictors"]])])
-    test_target <- test[, .v(options[["target"]])]
+    train_pred <- as.matrix(train[,options[["predictors"]]])
+    train_target <- train[, options[["target"]]]
+    valid_pred <- as.matrix(valid[,options[["predictors"]]])
+    valid_target <- valid[, options[["target"]]]
+    test_pred <- as.matrix(test[,options[["predictors"]]])
+    test_target <- test[, options[["target"]]]
     
     regfit_train <- glmnet::cv.glmnet(x = train_pred, y = train_target, nfolds = 10, type.measure = "deviance",
                                     family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha, 
@@ -173,8 +173,8 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   }
   
   # Use the specified model to make predictions for dataset
-  predictions <- predict(regfit_train, newx = as.matrix(dataset[,.v(options[["predictors"]])]), s = lambda, type = "link", exact = TRUE,
-                          x = as.matrix(dataset[,.v(options[["predictors"]])]), y = dataset[, .v(options[["target"]])], weights = weights, offset = NULL,
+  predictions <- predict(regfit_train, newx = as.matrix(dataset[,options[["predictors"]]]), s = lambda, type = "link", exact = TRUE,
+                          x = as.matrix(dataset[,options[["predictors"]]]), y = dataset[, options[["target"]]], weights = weights, offset = NULL,
                           alpha = alpha, standardize = FALSE, intercept = options[["intercept"]], thresh = options[["thresh"]])
   
   regressionResult <- list()
@@ -182,8 +182,8 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   regressionResult[["lambda"]]              <- lambda
   regressionResult[["penalty"]]             <- penalty
   regressionResult[["alpha"]]               <- alpha
-  regressionResult[["testMSE"]]             <- mean( (as.numeric(pred_test) -  test[,.v(options[["target"]])])^2 )
-  regressionResult[["testReal"]]            <- test[,.v(options[["target"]])]
+  regressionResult[["testMSE"]]             <- mean( (as.numeric(pred_test) -  test[,options[["target"]]])^2 )
+  regressionResult[["testReal"]]            <- test[,options[["target"]]]
   regressionResult[["testPred"]]            <- as.numeric(pred_test)
   regressionResult[["ntrain"]]              <- nrow(train)
 	regressionResult[["ntest"]]               <- nrow(test)
@@ -194,7 +194,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   regressionResult[["values"]]              <- predictions
 
   if(options[["modelOpt"]] != "optimizationManual"){
-    regressionResult[["validMSE"]]          <- mean( (as.numeric(pred_valid) -  valid[,.v(options[["target"]])])^2 )
+    regressionResult[["validMSE"]]          <- mean( (as.numeric(pred_valid) -  valid[,options[["target"]]])^2 )
     regressionResult[["nvalid"]]            <- nrow(valid)
   }
   
@@ -232,10 +232,10 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   coefTab <- regressionResult[["coefTable"]]
 
   if(!options[["intercept"]]){
-    labs <- .unv(rownames(coefTab))[-1]
+    labs <- rownames(coefTab)[-1]
     values <- as.numeric(coefTab)[-1]
   } else {
-    labs <- c("(Intercept)", .unv(rownames(coefTab)[-1]))
+    labs <- c("(Intercept)", rownames(coefTab[-1]))
     values <- as.numeric(coefTab)
   }
   
@@ -263,7 +263,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   model         <- regressionResult[["model"]]$glmnet.fit
   coefs         <- as.matrix(regressionResult[["model"]]$glmnet.fit$beta)
   d             <- stack(as.data.frame(coefs))
-  d$ind         <- rep(.unv(rownames(coefs)), (nrow(d) / nrow(coefs)))
+  d$ind         <- rep(rownames(coefs), (nrow(d) / nrow(coefs)))
   d$lambda      <- rep(model$lambda, each = nrow(coefs))
 
   xBreaks <- jaspGraphs::getPrettyAxisBreaks(d$lambda, min.n = 4)


### PR DESCRIPTION
@JorisGoosen this is no longer necessary, right?

FWIW, I removed these with:
```r
library(rex)

Rfiles <- list.files(file.path("jaspMachineLearning", "R"), pattern = "*.R$", full.names = TRUE)
for (file in Rfiles) {
  text <- readChar(file, file.info(file)$size)
  text <- re_substitutes(
    text,
    rex(
      ".v(",
      capture(name = "text", except_any_of(")")),
      ")"
    ),
    replacement = "\\1",
    global = TRUE
  )
  text <- re_substitutes(
    text,
    rex(
      ".unv(",
      capture(name = "text", except_any_of(")")),
      ")"
    ),
    replacement = "\\1",
    global = TRUE
  )
  cat(text, file = file)
}
```
I could've written the regular expression myself (or used only 1 regular expression) but this was way faster and worked seamlessly. Every change should be double-checked though because this will mess up calls of the form:
```r
.v(c(thing1, functionCall(thing2), thing3))
```
The regex matches the first `)`, so in the example above it matches `thing2)` and return `c(thing1, functionCall(thing2, thing3))`.

@koenderks I already double-checked each call, but it'd be great if you could take another look.

Edit: looks like I didn't check it good enough:
![image](https://user-images.githubusercontent.com/21319932/101056658-7f748100-358b-11eb-923e-179a13001f76.png)
