### PR TITLE
Add temporary call to library so that kknn classification does not crash

### DIFF
--- a/R/mlClassificationKnn.R
+++ b/R/mlClassificationKnn.R
@@ -16,7 +16,7 @@
 #
 
 mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
-  
+  	library(kknn)
     # Preparatory work
     dataset <- .readDataClassificationAnalyses(dataset, options)
     .errorHandlingClassificationAnalyses(dataset, options, type = "knn")


### PR DESCRIPTION
@vandenman @JorisGoosen Not sure if we should do this, but made the PR in case you guys think this is a good temporary solution.

Issue: https://github.com/jasp-stats/INTERNAL-jasp/issues/1227