### PR TITLE
Copy "gbmCrossValModelBuild" and "gbmCrossValErr" from jaspBase

### DIFF
--- a/R/commonMachineLearningClustering.R
+++ b/R/commonMachineLearningClustering.R
@@ -32,7 +32,7 @@
 
   customChecks <- .getCustomErrorChecksClustering(dataset, options, type)
   if(length(predictors[predictors != ""]) > 0L)
-    .hasErrors(dataset, type = c('infinity', 'observations'), custom=customChecks, 
+    .hasErrors(dataset, type = c('infinity', 'observations'), custom=customChecks,
                 all.target = predictors, observations.amount = "< 2", exitAnalysisIfErrors = TRUE)
 
   return()
@@ -224,8 +224,8 @@
     }
   }
 
-  row <- data.frame(cluster = cluster, 
-                    size = size, 
+  row <- data.frame(cluster = cluster,
+                    size = size,
                     percentage = withinss / sum(withinss))
 
   if(options[["tableClusterInfoWSS"]])
@@ -277,11 +277,11 @@
   distance <- dist(dataset)
   metrics <- fpc::cluster.stats(distance, clustering, silhouette = FALSE, sepindex = FALSE, sepwithnoise = FALSE)
 
-  clusterEvaluationMetrics[["metric"]] <- c(gettext("Maximum diameter"), 
-                                            gettext("Minimum separation"), 
-                                            gettextf("Pearson's %s", "\u03B3"), 
-                                            gettext("Dunn index"), 
-                                            gettext("Entropy"), 
+  clusterEvaluationMetrics[["metric"]] <- c(gettext("Maximum diameter"),
+                                            gettext("Minimum separation"),
+                                            gettextf("Pearson's %s", "\u03B3"),
+                                            gettext("Dunn index"),
+                                            gettext("Entropy"),
                                             gettext("Calinski-Harabasz index"))
 
   if(length(unique(clustering)) != 1){
@@ -422,13 +422,13 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
         ggplot2::scale_y_continuous(name = "", breaks = yBreaks, labels = yBreaks) +
         ggplot2::scale_linetype_manual(values = c(3, 2, 1)) +
         ggplot2::labs(linetype = "")
-  
+
   if(options[["optimizationCriterion"]] != "validationSilh"){
     p <- p + jaspGraphs::geom_point(data = pointData, ggplot2::aes(x = x, y = y, linetype = type, fill = "red")) +
               ggplot2::scale_fill_manual(labels = gettextf("Lowest %s value", requiredPoint), values = "red") +
-              ggplot2::labs(fill = "") 
+              ggplot2::labs(fill = "")
   }
-  
+
   p <- jaspGraphs::themeJasp(p, legend.position = "top")
 
   optimPlot$plotObject <- p
@@ -480,7 +480,7 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
   clusterLevels <- as.numeric(levels(clusters))
   clusterTitles <- gettextf("Cluster %s", clusterLevels)
   clusterMeans <- NULL
-  
+
   for(i in clusterLevels){
     clusterSubset <- subset(dataset, clusters == i)
     clusterMeans <- rbind(clusterMeans, colMeans(clusterSubset))
@@ -517,17 +517,17 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
 
     xBreaks <- jaspGraphs::getPrettyAxisBreaks(dataset[[variable]], min.n = 4)
 
-    plotData <- data.frame(Cluster = clusters, 
+    plotData <- data.frame(Cluster = clusters,
                            value = dataset[[variable]])
 
     p <- ggplot2::ggplot(plotData, ggplot2::aes(x = value, fill = Cluster)) +
           ggplot2::geom_density(color = "transparent", alpha = 0.6) +
           ggplot2::ylab(gettext("Density")) +
           ggplot2::scale_x_continuous(name = variable, breaks = xBreaks, labels = xBreaks, limits = range(xBreaks))
-    p <- jaspGraphs::themeJasp(p, legend.position = "right") + 
-          ggplot2::theme(axis.ticks.y = ggplot2::element_blank(), 
+    p <- jaspGraphs::themeJasp(p, legend.position = "right") +
+          ggplot2::theme(axis.ticks.y = ggplot2::element_blank(),
                          axis.text.y = ggplot2::element_blank())
-    
+
     clusterDensities[[variable]] <- createJaspPlot(plot = p, title = variable, height = 300, width = 500)
     clusterDensities[[variable]]$dependOn(optionContainsValue=list("predictors" = variable))
   }
@@ -555,17 +555,17 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
 
     clusters <- as.factor(clusterResult[["pred.values"]])
     xBreaks <- c(1, (as.numeric(levels(clusters)) + 1) * length(options[["predictors"]]))
-    
+
     clusterMeansData <- aggregate(dataset, list(clusters), mean)
     clusterSdData <- aggregate(dataset, list(clusters), sd)
     clusterLengthData <- aggregate(dataset, list(clusters), length)
-    
+
     clusterCoord <- rep(clusterMeansData[, 1], length(options[["predictors"]]))
 
     xCoord <- numeric()
     for(i in 1:length(options[["predictors"]])){
       if(i == 1){
-        xCoord <- c(xCoord, (length(xCoord) + 1):(length(xCoord) + length(clusterMeansData[, 1]))) 
+        xCoord <- c(xCoord, (length(xCoord) + 1):(length(xCoord) + length(clusterMeansData[, 1])))
       } else {
         xCoord <- c(xCoord, (max(xCoord) + 3):(max(xCoord) + 2 + length(clusterMeansData[, 1])))
       }
@@ -576,38 +576,38 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
     upperValues <- as.numeric(unlist(clusterMeansData[, -1])) + qnorm(0.95) * as.numeric(unlist(clusterSdData[, -1])) / sqrt(as.numeric(unlist(clusterLengthData[, -1])))
 
     plotData <- data.frame(xCoord = xCoord,
-                           Cluster = clusterCoord, 
+                           Cluster = clusterCoord,
                            value = values,
                            lower = lowerValues,
                            upper = upperValues)
-    
+
     yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, unlist(plotData[complete.cases(plotData), -c(1, 2)])), min.n = 4)
-    
+
     xBreaks <- (1:length(options[["predictors"]])) * (length(levels(clusters)) + 2)
     xBreaks <- xBreaks - (length(levels(clusters)) + 2)
     xBreaks <- xBreaks + 0.5 * length(levels(clusters))
-    
+
     xLabels <- options[["predictors"]]
-    
+
     plotData <- plotData[complete.cases(plotData), ]
 
     p <- ggplot2::ggplot(plotData, ggplot2::aes(x = xCoord, y = value, fill = Cluster))
-    
+
     if(options[["showBars"]]){
-      p <- p + ggplot2::geom_bar(color = "black", stat = "identity") + 
+      p <- p + ggplot2::geom_bar(color = "black", stat = "identity") +
         ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = xCoord, ymin=lower, ymax=upper), width = 0.2, size = 1)
     } else {
       p <- p + ggplot2::geom_segment(ggplot2::aes(x = 0, xend = max(plotData[["xCoord"]]), y = 0, yend = 0), linetype = 2) +
-                ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = xCoord, ymin=lower, ymax=upper), width = 0.2, size = 1) + 
+                ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = xCoord, ymin=lower, ymax=upper), width = 0.2, size = 1) +
                 jaspGraphs::geom_point(color = "black")
     }
-    
+
     p <- p + ggplot2::scale_x_continuous(name = "", breaks = xBreaks, labels = xLabels) +
       ggplot2::scale_y_continuous(name = gettext("Value"), breaks = yBreaks, labels = yBreaks, limits = range(yBreaks))
-    p <- jaspGraphs::themeJasp(p, legend.position = "right", sides = "l") + 
+    p <- jaspGraphs::themeJasp(p, legend.position = "right", sides = "l") +
           ggplot2::theme(axis.ticks.x = ggplot2::element_blank(),
                           axis.text.x = ggplot2::element_text(angle = 20))
-    
+
     clusterMeans[["oneFigure"]] <- createJaspPlot(plot = p, title = gettext("All predictors"), height = 400, width = 200 * length(options[["predictors"]]))
 
 
@@ -617,16 +617,16 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
 
       clusters <- as.factor(clusterResult[["pred.values"]])
       xBreaks <- as.numeric(levels(clusters))
-      
+
       clusterMeansData <- aggregate(dataset[[variable]], list(clusters), mean)
       clusterSdData <- aggregate(dataset[[variable]], list(clusters), sd)
       clusterLengthData <- aggregate(dataset[[variable]], list(clusters), length)
 
-      plotData <- data.frame(Cluster = clusterMeansData[, 1], 
+      plotData <- data.frame(Cluster = clusterMeansData[, 1],
                             value = clusterMeansData[, 2],
                             lower = clusterMeansData[, 2] - qnorm(0.95) * clusterSdData[, 2] / sqrt(clusterLengthData[, 2]),
                             upper = clusterMeansData[, 2] + qnorm(0.95) * clusterSdData[, 2] / sqrt(clusterLengthData[, 2]))
-      
+
       plotData <- plotData[complete.cases(plotData), ]
 
       yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, unlist(plotData[, -1])), min.n = 4)
@@ -634,18 +634,18 @@ if(!is.null(jaspResults[["optimPlot"]]) || !options[["withinssPlot"]] || options
       p <- ggplot2::ggplot(plotData, ggplot2::aes(x = Cluster, y = value, fill = Cluster))
 
       if(options[["showBars"]]){
-        p <- p + ggplot2::geom_bar(color = "black", stat = "identity") + 
+        p <- p + ggplot2::geom_bar(color = "black", stat = "identity") +
                   ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = Cluster, ymin=lower, ymax=upper), width = 0.2, size = 1)
       } else {
-        p <- p + ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = Cluster, ymin=lower, ymax=upper), width = 0.2, size = 1) + 
+        p <- p + ggplot2::geom_errorbar(data = plotData, ggplot2::aes(x = Cluster, ymin=lower, ymax=upper), width = 0.2, size = 1) +
                   jaspGraphs::geom_point(color = "black")
       }
 
       p <- p + ggplot2::scale_x_discrete(name = gettext("Cluster"), breaks = xBreaks, labels = xBreaks) +
                 ggplot2::scale_y_continuous(name = variable, breaks = yBreaks, labels = yBreaks, limits = range(yBreaks))
-      p <- jaspGraphs::themeJasp(p, sides = "l") + 
+      p <- jaspGraphs::themeJasp(p, sides = "l") +
             ggplot2::theme(axis.ticks.x = ggplot2::element_blank())
-      
+
       clusterMeans[[variable]] <- createJaspPlot(plot = p, title = variable, height = 300, width = 500)
       clusterMeans[[variable]]$dependOn(optionContainsValue=list("predictors" = variable))
     }

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -18,10 +18,10 @@
 .readDataRegressionAnalyses <- function(dataset, options, jaspResults){
   if (is.null(dataset))
     dataset <- .readDataClassificationRegressionAnalyses(dataset, options)
-  
+
   if (length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
     dataset[,c(options[["predictors"]], options[["target"]])] <- .scaleNumericData(dataset[,c(options[["predictors"]], options[["target"]]), drop = FALSE])
-  
+
   return(dataset)
 }
 
@@ -29,25 +29,25 @@
   target <- NULL
   if (options[["target"]] != "")
     target <- options[["target"]]
-  
+
   predictors <- NULL
   if (length(options[["predictors"]]) > 0)
     predictors <- unlist(options[["predictors"]])
-  
-  testSetIndicator <- NULL 
+
+  testSetIndicator <- NULL
   if (options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator")
     testSetIndicator <- options[["testSetIndicatorVariable"]]
-  
+
   return(.readAndAddCompleteRowIndices(dataset, columns = c(target, predictors), columnsAsNumeric = testSetIndicator))
 }
 
 .readAndAddCompleteRowIndices <- function(dataset, columns = NULL, columnsAsNumeric = NULL){
     dataset <- .readDataSetToEnd(columns = columns, columns.as.numeric = columnsAsNumeric)
-    
+
     complete.index      <- which(complete.cases(dataset))
     dataset             <- na.omit(dataset)
     rownames(dataset)   <- as.character(complete.index)
-    
+
     return(dataset)
 }
 
@@ -68,21 +68,21 @@
   if (options[["target"]] != "")
     target                  <- options[["target"]]
   variables.to.read         <- c(predictors, target)
-  
+
   if (length(variables.to.read) == 0)
     return()
-  
+
   if (options[["testSetIndicatorVariable"]] != "" && options[["holdoutData"]] == "testSetIndicator") {
-    
+
     if (options[["testSetIndicatorVariable"]] %in% predictors)
       jaspBase:::.quitAnalysis(gettextf("The variable '%s' can't be both a predictor and a test set indicator.", options[["testSetIndicatorVariable"]]))
-  
+
     indicatorVals <- unique(dataset[,options[["testSetIndicatorVariable"]]])
     if (length(indicatorVals) != 2 || !all(0:1 %in% indicatorVals))
       jaspBase:::.quitAnalysis(gettext("Your test set indicator should be binary, containing only 1 (included in test set) and 0 (excluded from test set)."))
-    
+
   }
-  
+
   customChecks <- .getCustomErrorChecksKnnBoosting(dataset, options, type)
   .hasErrors(dataset, type = c('infinity', 'observations'), custom = customChecks,
              all.target = variables.to.read,
@@ -116,11 +116,11 @@
         nTrain <- nTrainAndValid - 1
       valueToTest <- nTrain
     }
-    
+
     if (nn >= valueToTest)
       return(gettextf("You have specified more nearest neighbors than there are observations in the training set. Please choose a number lower than %d.", as.integer(valueToTest)))
   }
-  
+
   # check for too many folds (folds > nTrain+validation) before the analysis starts
   checkIfFoldsExceedValidation <- function() {
     if (options[["modelValid"]] == "validationKFold")  {
@@ -129,16 +129,16 @@
         return(gettextf("You have specified more folds than there are observations in the training and validation set. Please choose a number lower than %d.", as.integer(nTrainAndValid + 1)))
     }
   }
-  
+
   # check for too many observations in end nodes before the analysis starts
   checkMinObsNode <- function() {
     if (type != "boosting")
       return()
-      
+
     procentTrain <- (1 - options[["testDataManual"]])
     if (options[["modelOpt"]] == "optimizationOOB")
       procentTrain <- procentTrain * (1 - options[["validationDataManual"]])
-      
+
     nTrain <- nrow(dataset) * procentTrain
     bag.fraction <- options[["bagFrac"]]
     n.minobsinnode <- options[["nNode"]]
@@ -148,7 +148,7 @@
         nTrain * bag.fraction / 2 - 1
       ))
   }
-  
+
   return(list(checkNearestNeighbors, checkIfFoldsExceedValidation, checkMinObsNode))
 }
 
@@ -178,7 +178,7 @@
 
   if(ready){
     .regressionFormula(options, jaspResults)
-    
+
   if(type == "knn"){
     regressionResult <- .knnRegression(dataset, options, jaspResults)
   } else if(type == "regularized"){
@@ -234,7 +234,7 @@
 
     regressionTable$addColumnInfo(name = 'trees', title = gettext('Trees'),                type = 'integer')
     regressionTable$addColumnInfo(name = 'preds', title = gettext('Predictors per split'), type = 'integer')
-  
+
   } else if(type == "boosting"){
 
     regressionTable$addColumnInfo(name = 'trees',        title = gettext('Trees'),         type = 'integer')
@@ -267,7 +267,7 @@
     regressionTable$addFootnote(gettextf("Please provide a target variable and at least %d predictor variable(s).", requiredVars))
 
   jaspResults[["regressionTable"]] <- regressionTable
-  
+
   if(!ready)  return()
 
   .regressionMachineLearning(dataset, options, jaspResults, ready, type = type)
@@ -288,7 +288,7 @@
       nTrain <- nTrain - 1
     }
   }
-  
+
   # Fill the table per analysis
   if(type == "knn"){
 
@@ -299,10 +299,10 @@
       regressionTable$addFootnote(gettext("The optimum number of nearest neighbors is the maximum number. You might want to adjust the range of optimization."))
     }
 
-    distance  <- ifelse(regressionResult[["distance"]] == 1, yes = "Manhattan", no = "Euclidean")    
-    row <- data.frame(nn = regressionResult[["nn"]], 
-                      weights = regressionResult[["weights"]], 
-                      distance = distance, 
+    distance  <- ifelse(regressionResult[["distance"]] == 1, yes = "Manhattan", no = "Euclidean")
+    row <- data.frame(nn = regressionResult[["nn"]],
+                      weights = regressionResult[["weights"]],
+                      distance = distance,
                       ntrain = nTrain,
                       ntest = regressionResult[["ntest"]],
                       testMSE = regressionResult[["testMSE"]])
@@ -318,10 +318,10 @@
     if (regressionResult[["lambda"]] == 0)
       regressionTable$addFootnote(gettextf("When %s is set to 0 linear regression is performed.", "\u03BB"))
 
-    row <- data.frame(penalty = regressionResult[["penalty"]], 
-                      lambda = regressionResult[["lambda"]], 
-                      ntrain = nTrain, 
-                      ntest = regressionResult[["ntest"]], 
+    row <- data.frame(penalty = regressionResult[["penalty"]],
+                      lambda = regressionResult[["lambda"]],
+                      ntrain = nTrain,
+                      ntest = regressionResult[["ntest"]],
                       testMSE = regressionResult[["testMSE"]])
     if(options[["modelOpt"]] != "optimizationManual")
       row <- cbind(row, nvalid = nValid, validMSE = regressionResult[["validMSE"]])
@@ -334,11 +334,11 @@
     if(options[["modelOpt"]] == "optimizationError")
       regressionTable$addFootnote(gettext("The model is optimized with respect to the <i>out-of-bag mean squared error</i>."))
 
-    row <- data.frame(trees = regressionResult[["noOfTrees"]], 
-                      preds = regressionResult[["predPerSplit"]], 
+    row <- data.frame(trees = regressionResult[["noOfTrees"]],
+                      preds = regressionResult[["predPerSplit"]],
                       ntrain = nTrain,
                       ntest = regressionResult[["ntest"]],
-                      testMSE = regressionResult[["testMSE"]], 
+                      testMSE = regressionResult[["testMSE"]],
                       oob = regressionResult[["oobError"]])
     if(options[["modelOpt"]] != "optimizationManual")
       row <- cbind(row, nvalid = nValid, validMSE = regressionResult[["validMSE"]])
@@ -350,9 +350,9 @@
       regressionTable$addFootnote(gettext("The model is optimized with respect to the <i>out-of-bag mean squared error</i>."))
 
     distribution <- .regressionGetDistributionFromDistance(options[["distance"]])
-    row <- data.frame(trees = regressionResult[["noOfTrees"]], 
-                      shrinkage = options[["shrinkage"]], 
-                      distribution = distribution, 
+    row <- data.frame(trees = regressionResult[["noOfTrees"]],
+                      shrinkage = options[["shrinkage"]],
+                      distribution = distribution,
                       ntrain = nTrain,
                       ntest = regressionResult[["ntest"]],
                       testMSE = regressionResult[["testMSE"]])
@@ -365,9 +365,9 @@
 
 .regressionGetDistributionFromDistance <- function(distance) {
   return(switch(
-    distance, 
-    "tdist"    = gettext("t"), 
-    "gaussian" = gettext("Gaussian"), 
+    distance,
+    "tdist"    = gettext("t"),
+    "gaussian" = gettext("Gaussian"),
     "laplace"  = gettext("Laplace")
   ))
 }
@@ -375,7 +375,7 @@
 .regressionEvaluationMetrics <- function(dataset, options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["validationMeasures"]]) || !options[["validationMeasures"]]) return()
-  
+
   validationMeasures <- createJaspTable(title = "Evaluation Metrics")
   validationMeasures$position <- position
   validationMeasures$dependOn(options = c("validationMeasures", "noOfNearestNeighbours", "trainingDataManual", "distanceParameterManual", "weights", "scaleEqualSD", "modelOpt",
@@ -389,7 +389,7 @@
 
   measures <- c("MSE", "RMSE", "MAE", "MAPE", "R\u00B2")
   validationMeasures[["measures"]] <- measures
-  
+
   jaspResults[["validationMeasures"]] <- validationMeasures
 
   if(!ready)  return()
@@ -413,7 +413,7 @@
 
   if(is.na(r_squared))
     validationMeasures$addFootnote(gettextf("R%s cannot be computed due to lack of variance in the predictions.</i>", "\u00B2"))
-  
+
 }
 
 .regressionPredictedPerformancePlot <- function(options, jaspResults, ready, position){
@@ -432,7 +432,7 @@
   if(!ready) return()
 
   regressionResult <- jaspResults[["regressionResult"]]$object
-  
+
   predPerformance <- data.frame(true = c(regressionResult[["testReal"]]), predicted = regressionResult[["testPred"]])
 
   allBreaks <- jaspGraphs::getPrettyAxisBreaks(predPerformance[, 1], min.n = 4)
@@ -461,7 +461,7 @@
     result <- base::switch(purpose,
   						"classification" = jaspResults[["classificationResult"]]$object,
 						  "regression" = jaspResults[["regressionResult"]]$object)
-  
+
   if(options[["modelOpt"]] == "optimizationManual"){
     # For a fixed model, draw only a training and a test set
 
@@ -478,11 +478,11 @@
             ggplot2::xlab("") +
             ggplot2::ylab("") +
             ggplot2::scale_fill_manual(values = c("tomato2", "steelblue2")) +
-            ggplot2::annotate("text", y = c(0, nTrain, nTrain + nTest), x = 1, label = c(gettextf("Train: %d", nTrain), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrain + nTest)), size = 4, vjust = 0.5, hjust = -0.1) 
+            ggplot2::annotate("text", y = c(0, nTrain, nTrain + nTest), x = 1, label = c(gettextf("Train: %d", nTrain), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrain + nTest)), size = 4, vjust = 0.5, hjust = -0.1)
       p <- jaspGraphs::themeJasp(p, xAxis = FALSE, yAxis = FALSE)
 
-      p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(), 
-                              axis.text.y = ggplot2::element_blank(), 
+      p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(),
+                              axis.text.y = ggplot2::element_blank(),
                               axis.text.x = ggplot2::element_blank())
 
   } else {
@@ -503,13 +503,13 @@
             ggplot2::xlab("") +
             ggplot2::ylab("") +
             ggplot2::scale_fill_manual(values = c("tomato2", "darkgoldenrod2", "steelblue2")) +
-            ggplot2::annotate("text", y = c(0, nTrain, nTrain + nValid, nTrain + nValid + nTest), x = 1, 
-                              label = c(gettextf("Train: %d", nTrain), gettextf("Validation: %d", nValid), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrain + nValid + nTest)), 
-                              size = 4, vjust = 0.5, hjust = -0.1) 
+            ggplot2::annotate("text", y = c(0, nTrain, nTrain + nValid, nTrain + nValid + nTest), x = 1,
+                              label = c(gettextf("Train: %d", nTrain), gettextf("Validation: %d", nValid), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrain + nValid + nTest)),
+                              size = 4, vjust = 0.5, hjust = -0.1)
       p <- jaspGraphs::themeJasp(p, xAxis = FALSE, yAxis = FALSE)
 
-      p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(), 
-                              axis.text.y = ggplot2::element_blank(), 
+      p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(),
+                              axis.text.y = ggplot2::element_blank(),
                               axis.text.x = ggplot2::element_blank())
 
     } else {
@@ -527,9 +527,9 @@
             ggplot2::xlab("") +
             ggplot2::ylab("") +
             ggplot2::scale_fill_manual(values = c("tomato2", "seagreen2")) +
-            ggplot2::annotate("text", y = c(0, nTrainAndValid, nTrainAndValid + nTest), x = 1, 
-                              label = c(gettextf("Train and validation: %d", nTrainAndValid), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrainAndValid + nTest)), 
-                              size = 4, vjust = 0.5, hjust = -0.1) 
+            ggplot2::annotate("text", y = c(0, nTrainAndValid, nTrainAndValid + nTest), x = 1,
+                              label = c(gettextf("Train and validation: %d", nTrainAndValid), gettextf("Test: %d", nTest), gettextf("Total: %d", nTrainAndValid + nTest)),
+                              size = 4, vjust = 0.5, hjust = -0.1)
       p <- jaspGraphs::themeJasp(p, xAxis = FALSE, yAxis = FALSE)
 
       p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(), axis.text.y = ggplot2::element_blank(), axis.text.x = ggplot2::element_blank())
@@ -558,7 +558,7 @@
                                                               "intDepth", "nNode", "distance", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual",
                                                               "holdoutData", "testDataManual", "testIndicatorColumn", "addIndicator"))
     jaspResults[["testIndicatorColumn"]]$setNominal(testIndicatorColumn)
-  }  
+  }
 }
 
 # these could also extend the S3 method scale although that could be somewhat unexpected
@@ -614,6 +614,6 @@
                                                               "intDepth", "nNode", "distance", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual",
                                                               "holdoutData", "testDataManual", "testIndicatorColumn"))
     jaspResults[["valueColumn"]]$setScale(valueColumn)
-  }  
+  }
 }
 

--- a/R/mlClassificationBoosting.R
+++ b/R/mlClassificationBoosting.R
@@ -16,11 +16,11 @@
 #
 
 mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
-  
+
   # Preparatory work
   dataset <- .readDataClassificationAnalyses(dataset, options)
   .errorHandlingClassificationAnalyses(dataset, options, type = "boosting")
-  
+
   # Check if analysis is ready to run
   ready <- .classificationAnalysesReady(options, type = "boosting")
 
@@ -65,7 +65,7 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
 
   # Decision boundaries
   .classificationDecisionBoundaries(dataset, options, jaspResults, ready, position = 12, type = "boosting")
-  
+
 }
 
 .boostingClassification <- function(dataset, options, jaspResults) {
@@ -106,7 +106,7 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
                       shrinkage = options[["shrinkage"]], interaction.depth = options[["intDepth"]],
                       cv.folds = noOfFolds, bag.fraction = options[["bagFrac"]], n.minobsinnode = options[["nNode"]],
                       distribution = "multinomial", n.cores = 1, keep.data = TRUE) # Multiple cores breaks modules in JASP, see: INTERNAL-jasp#372
- 
+
     noOfTrees <- options[["noOfTrees"]]
 
   } else if(options[["modelOpt"]] == "optimizationOOB"){
@@ -159,7 +159,7 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
   classificationResult[['confTable']]           <- table('Pred' = pred_test, 'Real' = test[,options[["target"]]])
   classificationResult[['testAcc']]             <- sum(diag(prop.table(classificationResult[['confTable']])))
   classificationResult[["relInf"]]              <- summary(bfit, plot = FALSE)
-  classificationResult[["auc"]]                 <- auc 
+  classificationResult[["auc"]]                 <- auc
   classificationResult[["ntrain"]]              <- nrow(train)
   classificationResult[["ntest"]]               <- nrow(test)
   classificationResult[["testPred"]]            <- pred_test

--- a/R/mlClassificationBoosting.R
+++ b/R/mlClassificationBoosting.R
@@ -70,8 +70,8 @@ mlClassificationBoosting <- function(jaspResults, dataset, options, ...) {
 
 .boostingClassification <- function(dataset, options, jaspResults) {
 
-  assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
-  assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")
+  jaspBase:::assignFunctionInPackage(fakeGbmCrossValModelBuild, "gbmCrossValModelBuild", "gbm")
+  jaspBase:::assignFunctionInPackage(fakeGbmCrossValErr,        "gbmCrossValErr",        "gbm")
 
   # Import model formula from jaspResults
   formula <- jaspResults[["formula"]]$object

--- a/R/mlClassificationKnn.R
+++ b/R/mlClassificationKnn.R
@@ -16,14 +16,14 @@
 #
 
 mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
-  
+
     # Preparatory work
     dataset <- .readDataClassificationAnalyses(dataset, options)
     .errorHandlingClassificationAnalyses(dataset, options, type = "knn")
-    
+
     # Check if analysis is ready to run
     ready <- .classificationAnalysesReady(options, type = "knn")
-    
+
     # Compute results and create the model summary table
     .classificationTable(dataset, options, jaspResults, ready, position = 1, type = "knn")
 
@@ -35,7 +35,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
 
     # Create the data split plot
 	  .dataSplitPlot(dataset, options, jaspResults, ready, position = 2, purpose = "classification", type = "knn")
-    
+
     # Create the confusion table
     .classificationConfusionTable(dataset, options, jaspResults, ready, position = 3)
 
@@ -44,7 +44,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
 
     # Create the validation measures table
     .classificationEvaluationMetrics(dataset, options, jaspResults, ready, position = 5)
-    
+
     # Create the classification error plot
     .knnErrorPlot(dataset, options, jaspResults, ready, position = 6, purpose = "classification")
 
@@ -56,7 +56,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
 
     # Decision boundaries
     .classificationDecisionBoundaries(dataset, options, jaspResults, ready, position = 9, type = "knn")
-    
+
 }
 
 .knnClassification <- function(dataset, options, jaspResults) {
@@ -81,13 +81,13 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
   # Create the generated test set indicator
 	testIndicatorColumn <- rep(1, nrow(dataset))
   testIndicatorColumn[train.index] <- 0
-	
+
 	if(options[["modelOpt"]] == "optimizationManual"){
 		# Just create a train and a test set (no optimization)
 		train                   <- trainAndValid
 		test                    <- dataset[-train.index, ]
 
-		kfit_test <- kknn::kknn(formula = formula, train = train, test = test, k = options[['noOfNearestNeighbours']], 
+		kfit_test <- kknn::kknn(formula = formula, train = train, test = test, k = options[['noOfNearestNeighbours']],
 			                      distance = distance, kernel = weights, scale = FALSE)
 		nn <- options[['noOfNearestNeighbours']]
 
@@ -107,10 +107,10 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
       startProgressbar(length(nnRange))
 
       for(i in nnRange){
-          kfit_valid <- kknn::kknn(formula = formula, train = train, test = valid, k = i, 
+          kfit_valid <- kknn::kknn(formula = formula, train = train, test = valid, k = i,
               distance = options[['distanceParameterManual']], kernel = options[['weights']], scale = FALSE)
           accuracyStore[i] <- sum(diag(prop.table(table(kfit_valid$fitted.values, valid[,options[["target"]]]))))
-          kfit_train <- kknn::kknn(formula = formula, train = train, test = train, k = i, 
+          kfit_train <- kknn::kknn(formula = formula, train = train, test = train, k = i,
 				      distance = options[['distanceParameterManual']], kernel = options[['weights']], scale = FALSE)
 			    trainAccuracyStore[i] <- sum(diag(prop.table(table(kfit_train$fitted.values, train[,options[["target"]]]))))
           progressbarTick()
@@ -118,7 +118,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
 
       nn <- base::switch(options[["modelOpt"]],
                           "optimizationError" = nnRange[which.max(accuracyStore)])
-      kfit_test <- kknn::kknn(formula = formula, train = train, test = test, k = nn, 
+      kfit_test <- kknn::kknn(formula = formula, train = train, test = test, k = nn,
                 distance = options[['distanceParameterManual']], kernel = options[['weights']], scale = FALSE)
 
     } else if(options[["modelValid"]] == "validationKFold"){
@@ -140,7 +140,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
                         "optimizationError" = nnRange[which.max(accuracyStore)])
 
       kfit_valid <- kknn::cv.kknn(formula = formula, data = trainAndValid, distance = options[['distanceParameterManual']], kernel = options[['weights']],
-                            kcv = options[['noOfFolds']], k = nn)   
+                            kcv = options[['noOfFolds']], k = nn)
       kfit_valid <- list(fitted.values = kfit_valid[[1]][, 2])
 
       kfit_test <- kknn::kknn(formula = formula, train = trainAndValid, test = test, k = nn, distance = distance, kernel = weights, scale = FALSE)
@@ -152,7 +152,7 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
     } else if(options[["modelValid"]] == "validationLeaveOneOut"){
 
       nnRange <- 1:options[["maxK"]]
-      kfit_valid <- kknn::train.kknn(formula = formula, data = trainAndValid, ks = nnRange, scale = FALSE, distance = options[['distanceParameterManual']], kernel = options[['weights']])  
+      kfit_valid <- kknn::train.kknn(formula = formula, data = trainAndValid, ks = nnRange, scale = FALSE, distance = options[['distanceParameterManual']], kernel = options[['weights']])
       accuracyStore <- as.numeric(1 - kfit_valid$MISCLASS)
       nn <- base::switch(options[["modelOpt"]],
                             "optimizationError" = nnRange[which.max(accuracyStore)])
@@ -188,8 +188,8 @@ mlClassificationKnn <- function(jaspResults, dataset, options, ...) {
   classificationResult[["ntest"]]               <- nrow(test)
   classificationResult[["testReal"]]            <- test[,options[["target"]]]
   classificationResult[["testPred"]]            <- kfit_test$fitted.values
-  classificationResult[["train"]]               <- train 
-  classificationResult[["test"]]                <- test 
+  classificationResult[["train"]]               <- train
+  classificationResult[["test"]]                <- test
   classificationResult[["testIndicatorColumn"]] <- testIndicatorColumn
   classificationResult[["classes"]]             <- predictions
 

--- a/R/mlClassificationLda.R
+++ b/R/mlClassificationLda.R
@@ -16,14 +16,14 @@
 #
 
 mlClassificationLda <- function(jaspResults, dataset, options, ...) {
-  
+
   # Preparatory work
   dataset <- .readDataClassificationAnalyses(dataset, options)
   .errorHandlingClassificationAnalyses(dataset, options, type = "lda")
-  
+
   # Check if analysis is ready to run
   ready <- .classificationAnalysesReady(options, type = "lda")
-  
+
   # Compute results and create the model summary table
   .classificationTable(dataset, options, jaspResults, ready, position = 1, type = "lda")
 
@@ -69,28 +69,28 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   # Create the Andrews curves
   .classificationAndrewsCurves(dataset, options, jaspResults, ready, position = 13)
 
-  # Create the LDA matrix plot 
+  # Create the LDA matrix plot
   .ldaMatricesPlot(dataset, options, jaspResults, ready, position = 14)
 
   # Decision boundaries
   .classificationDecisionBoundaries(dataset, options, jaspResults, ready, position = 15, type = "lda")
-  
+
 }
 
-# Error handling 
+# Error handling
 .classLdaErrorHandling <- function(dataset, options){
   # Error Check 1: There should be at least 5 observations in the target variable
   .hasErrors(dataset = dataset, type = c('observations', 'variance', 'infinity'),
              all.target = options$target, observations.amount = '< 5', exitAnalysisIfErrors = TRUE)
-  
+
   # Error Check 2: The target variable should have at least 2 classes
   if (nlevels(dataset[, options$target]) < 2){
     jaspBase:::.quitAnalysis(gettext("The target variable should have at least 2 classes."))
   }
-  
+
 }
 
-# Compute results 
+# Compute results
 .ldaClassification <- function(dataset, options, jaspResults){
 
   # Import model formula from jaspResults
@@ -111,7 +111,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 	testIndicatorColumn <- rep(1, nrow(dataset))
   testIndicatorColumn[train.index] <- 0
 
-  method <- base::switch(options[["estimationMethod"]], 
+  method <- base::switch(options[["estimationMethod"]],
                           "moment" = "moment",
                           "mle" = "mle",
                           "covMve" = "mve",
@@ -145,22 +145,22 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   classificationResult[["test"]]                <- test
   classificationResult[["testIndicatorColumn"]] <- testIndicatorColumn
   classificationResult[["classes"]]             <- predictions
-  
+
   return(classificationResult)
 }
 
 .ldaClassificationCoefficients <- function(options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["coefficientsTable"]]) || !options[["coefficientsTable"]]) return()
-  
+
   coefficientsTable <- createJaspTable(title = gettext("Linear Discriminant Coefficients"))
   coefficientsTable$position <- position
   coefficientsTable$dependOn(options = c("coefficientsTable", "trainingDataManual", "scaleEqualSD", "modelOpt",
-                                          "target", "predictors", "seed", "seedBox", "modelValid", "estimationMethod", 
+                                          "target", "predictors", "seed", "seedBox", "modelValid", "estimationMethod",
                                           "testSetIndicatorVariable", "testSetIndicator", "validationDataManual",
                                           "holdoutData", "testDataManual"))
   coefficientsTable$addColumnInfo(name = "pred_level", title = "", type = "string")
-  
+
   jaspResults[["coefficientsTable"]] <- coefficientsTable
 
   if(!ready)  return()
@@ -177,16 +177,16 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   groupmean <- (classificationResult[["model"]]$prior %*% classificationResult[["model"]]$means)
   constants <- (groupmean %*% classificationResult[["scaling"]])
 
-  row <- cbind(pred_level = c(gettext("(Constant)"), rownames(coefficients)), 
+  row <- cbind(pred_level = c(gettext("(Constant)"), rownames(coefficients)),
                 as.data.frame(rbind(constants, coefficients)))
-    
-  coefficientsTable$addRows(row) 
+
+  coefficientsTable$addRows(row)
 }
 
 .ldaClassificationPriorPosterior <- function(options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["priorTable"]]) || !options[["priorTable"]]) return()
-  
+
   priorTable <- createJaspTable(title = gettext("Prior and Posterior Class Probabilities"))
   priorTable$position <- position
   priorTable$dependOn(options = c("priorTable", "trainingDataManual", "scaleEqualSD", "modelOpt",
@@ -197,13 +197,13 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   priorTable$addColumnInfo(name = "typeprob",  title = "",                   type = "string")
   priorTable$addColumnInfo(name = "prior",     title = gettext("Prior"),     type = "number")
   priorTable$addColumnInfo(name = "posterior", title = gettext("Posterior"), type = "number")
-  
+
   jaspResults[["priorTable"]] <- priorTable
 
   if(!ready)  return()
 
   classificationResult <- jaspResults[["classificationResult"]]$object
-    
+
   levelPriors <- classificationResult[["prior"]]
   levelPost <- classificationResult[["postprob"]]
 
@@ -214,7 +214,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 .ldaClassificationMeans <- function(options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["meanTable"]]) || !options[["meanTable"]]) return()
-  
+
   meanTable <- createJaspTable(title = gettext("Class Means in Training Data"))
   meanTable$position <- position
   meanTable$dependOn(options = c("meanTable", "trainingDataManual", "scaleEqualSD", "modelOpt", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual",
@@ -225,7 +225,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   for (i in options[["predictors"]]){
     meanTable$addColumnInfo(name = i, type = "number", title = i)
   }
-  
+
   jaspResults[["meanTable"]] <- meanTable
 
   if(!ready)  return()
@@ -233,25 +233,25 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   classificationResult <- jaspResults[["classificationResult"]]$object
   groupMeans <- classificationResult[["meanTable"]]
   colnames(groupMeans) <- colnames(groupMeans)
-  
-  row <- cbind(target_level = rownames(groupMeans), as.data.frame(groupMeans))  
+
+  row <- cbind(target_level = rownames(groupMeans), as.data.frame(groupMeans))
   meanTable$addRows(row)
 }
 
 .ldaMatricesPlot <- function(dataset, options, jaspResults, ready, position){
 
   if (!is.null(jaspResults[["matrixplot"]]) || !options[["matrixplot"]]) return()
-  
+
   matrixplot <- createJaspPlot(title = gettext("Linear Discriminant Matrix"), height = 400, width = 300)
   matrixplot$position <- position
   matrixplot$dependOn(options = c("matrixplot", "plotDensities", "plotStatistics", "trainingDataManual", "scaleEqualSD", "modelOpt", "holdoutData", "testDataManual",
                                           "target", "predictors", "seed", "seedBox", "modelValid", "estimationMethod", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual"))
-  jaspResults[["matrixplot"]] <- matrixplot 
+  jaspResults[["matrixplot"]] <- matrixplot
 
   if(!ready)  return()
 
   classificationResult <- jaspResults[["classificationResult"]]$object
-  
+
   .ldaFillMatrixPlot(dataset, options, jaspResults, classificationResult, matrixplot)
 }
 
@@ -273,14 +273,14 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   matrixplot[["width"]]  <- width
   matrixplot[["height"]] <- height
-  
+
   cexText <- 1.6
-  
+
   plotMat <- matrix(list(), l, l)
-  adjMargin <- ggplot2::theme(plot.margin = ggplot2::unit(c(.25, .40, .25, .25), "cm")) 
+  adjMargin <- ggplot2::theme(plot.margin = ggplot2::unit(c(.25, .40, .25, .25), "cm"))
   oldFontSize <- jaspGraphs::getGraphOption("fontsize")
   jaspGraphs::setGraphOption("fontsize", .85 * oldFontSize)
-  
+
   startProgressbar(length(plotMat)+1)
   for (row in seq_len(l)) {
     for (col in seq_len(l)) {
@@ -288,31 +288,31 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
         if (options[["plotDensities"]]) {
             plotMat[[row, col]] <- .ldaDensityplot(classificationResult, options, col) + adjMargin # plot marginal (histogram with density estimator)
         } else {
-          
+
           p <- jaspGraphs::drawAxis(xName = "", yName = "", force = TRUE) + adjMargin
           p <- p + ggplot2::xlab("")
           p <- p + ggplot2::ylab("")
           p <- jaspGraphs::themeJasp(p)
-          
+
           plotMat[[row, col]] <- p
         }
       }
-      
+
       if (col > row) {
         if (options[["plotStatistics"]]) {
             plotMat[[row, col]] <- .ldaScatterPlot(classificationResult, options, col) + adjMargin # plot scatterplot
-          
+
         } else {
-          
+
           p <- jaspGraphs::drawAxis(xName = "", yName = "", force = TRUE) + adjMargin
           p <- p + ggplot2::xlab("")
           p <- p + ggplot2::ylab("")
           p <- jaspGraphs::themeJasp(p)
-          
+
           plotMat[[row, col]] <- p
         }
       }
-      
+
       if (col < row) {
         if (l < 7) {
           if (options[["plotStatistics"]]) {
@@ -320,27 +320,27 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
             p <- p + ggplot2::xlab("")
             p <- p + ggplot2::ylab("")
             p <- jaspGraphs::themeJasp(p)
-            
+
             plotMat[[row, col]] <- p
-          
+
           } else {
-            
+
             p <- jaspGraphs::drawAxis(xName = "", yName = "", force = TRUE) + adjMargin
             p <- p + ggplot2::xlab("")
             p <- p + ggplot2::ylab("")
             p <- jaspGraphs::themeJasp(p)
-            
+
             plotMat[[row, col]] <- p
           }
         }
-        
+
         if (col == 1 && row == 2){
-          plotMat[[2, 1]] <- .legendPlot(dataset, options, col) 
+          plotMat[[2, 1]] <- .legendPlot(dataset, options, col)
         }
         progressbarTick()
       }
     }
-  }  
+  }
   jaspGraphs::setGraphOption("fontsize", oldFontSize)
   # slightly adjust the positions of the labels left and above the plots.
   labelPos <- matrix(.5, 4, 2)
@@ -348,11 +348,11 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   labelPos[4, 2] <- .65
   p <- jaspGraphs::ggMatrixPlot(plotList = plotMat, leftLabels = variables, topLabels = variables,
                                 scaleXYlabels = NULL, labelPos = labelPos)
-  
+
   progressbarTick()
   matrixplot$plotObject <- p
 }
-  
+
 .ldaDensityplot <- function(classificationResult, options, col){
 
   target <- classificationResult[["train"]][, options[["target"]]]
@@ -363,25 +363,25 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   lda.fit.scaled[["V2"]] <- as.factor(lda.fit.scaled[["V2"]])
 
   xBreaks <- jaspGraphs::getPrettyAxisBreaks(lda.fit.scaled[, "LD"], min.n = 4)
-  
+
   if (length(colnames(classificationResult[["scaling"]])) == 1) {
 
     p <- ggplot2::ggplot(data = lda.fit.scaled, ggplot2::aes(x = LD, group = V2, color = V2, show.legend = TRUE)) +
-          jaspGraphs::geom_line(stat = "density") + 
-          ggplot2::labs(color = options[["target"]]) + 
+          jaspGraphs::geom_line(stat = "density") +
+          ggplot2::labs(color = options[["target"]]) +
           ggplot2::theme(legend.key = ggplot2::element_blank()) +
           ggplot2::scale_color_manual(values = colorspace::qualitative_hcl(n = length(unique(target)))) +
           ggplot2::scale_x_continuous(name = "", breaks = xBreaks, limits = range(xBreaks)) +
           ggplot2::scale_y_continuous(name = gettext("Density"))
-    
+
     p <- jaspGraphs::themeJasp(p, legend.position = "right")
     p <- p + ggplot2::theme(axis.ticks.y = ggplot2::element_blank(), axis.text.y = ggplot2::element_blank())
     p <- p + ggplot2::guides(color = ggplot2::guide_legend(override.aes = list(shape = 21)))
-    
+
   } else {
 
     p <- ggplot2::ggplot(data = lda.fit.scaled, ggplot2::aes(x = LD, group = V2, color = V2)) +
-          jaspGraphs::geom_line(stat = "density") + 
+          jaspGraphs::geom_line(stat = "density") +
           ggplot2::scale_color_manual(values = colorspace::qualitative_hcl(n = length(unique(target)))) +
           ggplot2::scale_x_continuous(name = "", breaks = xBreaks, limits = range(xBreaks)) +
           ggplot2::scale_y_continuous(name = gettext("Density"))
@@ -404,22 +404,22 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 
   xBreaks <- jaspGraphs::getPrettyAxisBreaks(lda.data[, "x"], min.n = 4)
   yBreaks <- jaspGraphs::getPrettyAxisBreaks(lda.data[, "y"], min.n = 4)
-  
+
   p <- ggplot2::ggplot(lda.data, ggplot2::aes(x = x, y = y)) +
-        jaspGraphs::geom_point(ggplot2::aes(fill = target)) + 
-        ggplot2::labs(fill = options[["target"]]) + 
+        jaspGraphs::geom_point(ggplot2::aes(fill = target)) +
+        ggplot2::labs(fill = options[["target"]]) +
         ggplot2::scale_fill_manual(values = colorspace::qualitative_hcl(n = length(unique(target)))) +
-        ggplot2::scale_x_continuous(name = "", breaks = xBreaks, limits = range(xBreaks)) + 
+        ggplot2::scale_x_continuous(name = "", breaks = xBreaks, limits = range(xBreaks)) +
         ggplot2::scale_y_continuous(name = "", breaks = yBreaks, limits = range(yBreaks))
-  p <- jaspGraphs::themeJasp(p)    
-  
+  p <- jaspGraphs::themeJasp(p)
+
   return(p)
 }
 
 .ldaEqualityOfClassMeans <- function(dataset, options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["manovaTable"]]) || !options[["manovaTable"]]) return()
-  
+
   manovaTable <- createJaspTable(title = gettext("Tests of Equality of Class Means"))
   manovaTable$position <- position
   manovaTable$dependOn(options = c("manovaTable", "scaleEqualSD", "target", "predictors"))
@@ -430,7 +430,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   manovaTable$addColumnInfo(name = "p", title = "p", type = "pvalue")
 
   manovaTable$addFootnote(gettext("The null hypothesis specifies equal class means."))
-  
+
   jaspResults[["manovaTable"]] <- manovaTable
 
   if(!ready)  return()
@@ -441,7 +441,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   tryCatch({
     manovaResult <- manova(predictors ~ target)
     manovaSummary <- summary(manovaResult, test="Wilks")
-    
+
     # Individual models
     anovaSummary <- summary.aov(manovaResult)
     for(i in 1:length(anovaSummary)){
@@ -461,7 +461,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 .ldaEqualityOfCovarianceMatrices <- function(dataset, options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["boxTest"]]) || !options[["boxTest"]]) return()
-  
+
   boxTest <- createJaspTable(title = gettext("Tests of Equality of Covariance Matrices"))
   boxTest$position <- position
   boxTest$dependOn(options = c("boxTest", "scaleEqualSD", "target", "predictors"))
@@ -472,7 +472,7 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
   boxTest$addColumnInfo(name = "p",    title = gettext("p"),   type = "pvalue")
 
   boxTest$addFootnote(gettext("The null hypothesis specifies equal covariance matrices."))
-  
+
   jaspResults[["boxTest"]] <- boxTest
 
   if(!ready)  return()
@@ -493,11 +493,11 @@ mlClassificationLda <- function(jaspResults, dataset, options, ...) {
 .ldaMulticollinearity <- function(dataset, options, jaspResults, ready, position){
 
   if(!is.null(jaspResults[["multicolTable"]]) || !options[["multicolTable"]]) return()
-  
+
   multicolTable <- createJaspTable(title = gettext("Pooled Within-Class Matrices Correlations"))
   multicolTable$position <- position
   multicolTable$dependOn(options = c("multicolTable", "scaleEqualSD", "target", "predictors"))
-  
+
   jaspResults[["multicolTable"]] <- multicolTable
 
   if(!ready)  return()

--- a/R/mlClassificationRandomForest.R
+++ b/R/mlClassificationRandomForest.R
@@ -16,11 +16,11 @@
 #
 
 mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
-  
+
   # Preparatory work
   dataset <- .readDataClassificationAnalyses(dataset, options)
   .errorHandlingClassificationAnalyses(dataset, options, type = "randomForest")
-  
+
   # Check if analysis is ready to run
   ready <- .classificationAnalysesReady(options, type = "randomForest")
 
@@ -65,11 +65,11 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
 
   # Decision boundaries
   .classificationDecisionBoundaries(dataset, options, jaspResults, ready, position = 12, type = "randomForest")
-  
+
 }
 
 .randomForestClassification <- function(dataset, options, jaspResults) {
-  
+
   # Set model-specific parameters
   noOfPredictors <- base::switch(options[["noOfPredictors"]], "manual" = options[["numberOfPredictors"]], "auto" = floor(sqrt(length(options[["predictors"]]))))
 
@@ -102,7 +102,7 @@ mlClassificationRandomForest <- function(jaspResults, dataset, options, ...) {
                                             sampsize = ceiling(options[["bagFrac"]]*nrow(train)),
                                             importance = TRUE, keep.forest = TRUE)
     noOfTrees <- options[["noOfTrees"]]
-    
+
   } else if(options[["modelOpt"]] == "optimizationError"){
     # Create a train, validation and test set (optimization)
     valid.index             <- sample.int(nrow(trainAndValid), size = ceiling(options[['validationDataManual']] * nrow(trainAndValid)))

--- a/R/mlClusteringFuzzyCMeans.R
+++ b/R/mlClusteringFuzzyCMeans.R
@@ -16,11 +16,11 @@
 #
 
 mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
-  
+
   # Preparatory work
   dataset <- .readDataClusteringAnalyses(dataset, options)
   .errorHandlingClusteringAnalyses(dataset, options, type = "cmeans")
-  
+
   # Check if analysis is ready to run
   ready  <- .clusterAnalysesReady(options)
 
@@ -29,7 +29,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
 
   # If the user wants to add the clusters to the data set
   .clusteringAddClustersToData(dataset, options, jaspResults, ready)
-  
+
   # Create the cluster information table
   .clusterInformationTable(options, jaspResults, ready, position = 2, type = "cmeans")
 
@@ -50,17 +50,17 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
 
   # Create the cluster plot
   .tsneClusterPlot(dataset, options, jaspResults, ready, position = 8, type = "cmeans")
-  
+
 }
 
 .cMeansClustering <- function(dataset, options, jaspResults, ready){
-  
+
   if(options[["modelOpt"]] == "validationManual"){
-      
+
     cfit <- e1071::cmeans(dataset[, options[["predictors"]]],
                             centers = options[['noOfClusters']],
                             iter.max = options[['noOfIterations']],
-                            m = options[["m"]], 
+                            m = options[["m"]],
                             method = "ufcl") # method = "cmeans" can yield a number of clusters that is not equal to the requested number
 
     clusters <- options[['noOfClusters']]
@@ -86,7 +86,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
 
       v_tmp <- cfit_tmp$centers
       clabels_tmp <- cfit_tmp$cluster
-      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp) 
+      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp)
       wssStore[i - 1] <- csumsqrs_tmp$tot.within.ss
 
       m <- ncol(cfit_tmp$centers)
@@ -95,7 +95,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
       D <- csumsqrs_tmp$tot.within.ss
       aicStore[i - 1] <- D + 2*m*k
       bicStore[i - 1] <- D + log(n)*m*k
-      
+
       progressbarTick()
   }
 
@@ -103,7 +103,7 @@ mlClusteringFuzzyCMeans <- function(jaspResults, dataset, options, ...) {
                             "validationSilh" = clusterRange[which.max(avg_silh)],
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
-  
+
   cfit <- e1071::cmeans(dataset[, options[["predictors"]]],
                           centers = clusters,
                           iter.max = options[['noOfIterations']],

--- a/R/mlClusteringHierarchical.R
+++ b/R/mlClusteringHierarchical.R
@@ -16,11 +16,11 @@
 #
 
 mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
-  
+
   # Preparatory work
   dataset <- .readDataClusteringAnalyses(dataset, options)
   .errorHandlingClusteringAnalyses(dataset, options, type = "hierarchical")
-  
+
   # Check if analysis is ready to run
   ready  <- .clusterAnalysesReady(options)
 
@@ -29,7 +29,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
 
   # If the user wants to add the clusters to the data set
   .clusteringAddClustersToData(dataset, options, jaspResults, ready)
-  
+
   # Create the cluster information table
   .clusterInformationTable(options, jaspResults, ready, position = 2, type = "hierarchical")
 
@@ -41,7 +41,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
 
   # Create the within sum of squares plot
   .elbowCurvePlot(dataset, options, jaspResults, ready, position = 5)
-  
+
   # Create dendrogram
   .hierarchicalClusteringDendogram(dataset, options, jaspResults, ready, position = 6)
 
@@ -53,13 +53,13 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
 
   # Create the cluster plot
   .tsneClusterPlot(dataset, options, jaspResults, ready, position = 9, type = "hierarchical")
-  
+
 }
 
 .hierarchicalClustering <- function(dataset, options, jaspResults){
-  
+
   if(options[["modelOpt"]] == "validationManual"){
-        
+
     if (options[["distance"]] == "Pearson correlation") {
       distances <- as.dist(1 - cor(t(dataset[, options[["predictors"]]]), method = "pearson"))
       distances[is.na(distances)] <- 1 # We impute the missing correlations with a 1, as 1 - 1 = 0
@@ -113,7 +113,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
       bic <- D + log(n)*m*k
       aicStore[i - 1] <- D + 2*m*k
       bicStore[i - 1] <- D + log(n)*m*k
-      
+
       progressbarTick()
     }
 
@@ -121,11 +121,11 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
                               "validationSilh" = clusterRange[which.max(avg_silh)],
                               "validationAIC" = clusterRange[which.min(aicStore)],
                               "validationBIC" = clusterRange[which.min(bicStore)])
-    
+
     hfit <- cutree(hclust(distances, method = options[["linkage"]]), k = clusters)
 
   }
-  
+
   pred.values <- hfit
   clusters <- clusters
   size <- as.data.frame(table(hfit))[,2]
@@ -148,7 +148,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
   bic <- D + log(n)*m*k
 
   silhouettes <- summary(cluster::silhouette(hfit, distances))
-  
+
   Silh_score <- silhouettes[["avg.width"]]
   silh_scores <- silhouettes[["clus.avg.widths"]]
 
@@ -200,7 +200,7 @@ mlClusteringHierarchical <- function(jaspResults, dataset, options, ...) {
   } else {
     hc <- hclust(dist(data), method = options[["linkage"]])
   }
-  
+
   p <- ggdendro::ggdendrogram(hc)
   p <- jaspGraphs::themeJasp(p) + ggdendro::theme_dendro()
   dendrogram$plotObject <- p

--- a/R/mlClusteringKMeans.R
+++ b/R/mlClusteringKMeans.R
@@ -16,11 +16,11 @@
 #
 
 mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
-    
+
   # Preparatory work
   dataset <- .readDataClusteringAnalyses(dataset, options)
   .errorHandlingClusteringAnalyses(dataset, options, type = "kmeans")
-  
+
   # Check if analysis is ready to run
   ready  <- .clusterAnalysesReady(options)
 
@@ -29,7 +29,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
 
   # If the user wants to add the clusters to the data set
   .clusteringAddClustersToData(dataset, options, jaspResults, ready)
-  
+
   # Create the cluster information table
   .clusterInformationTable(options, jaspResults, ready, position = 2, type = "kmeans")
 
@@ -50,13 +50,13 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
 
   # Create the cluster plot
   .tsneClusterPlot(dataset, options, jaspResults, ready, position = 8, type = "kmeans")
-  
+
 }
 
 .kMeansClustering <- function(dataset, options, jaspResults, ready){
 
   if(options[["modelOpt"]] == "validationManual"){
-    
+
     kfit <- kmeans(dataset[, options[["predictors"]]],
                    centers = options[['noOfClusters']],
                    iter.max = options[['noOfIterations']],
@@ -86,7 +86,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
 
       v_tmp <- kfit_tmp$centers
       clabels_tmp <- kfit_tmp$cluster
-      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp) 
+      csumsqrs_tmp <- .sumsqr(dataset[, options[["predictors"]]], v_tmp, clabels_tmp)
       wssStore[i - 1] <- csumsqrs_tmp$tot.within.ss
 
       m <- ncol(kfit_tmp$centers)
@@ -95,7 +95,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
       D <- kfit_tmp$tot.withinss
       aicStore[i - 1] <- D + 2*m*k
       bicStore[i - 1] <- D + log(n)*m*k
-      
+
       progressbarTick()
   }
 
@@ -103,7 +103,7 @@ mlClusteringKMeans <- function(jaspResults, dataset, options, ...) {
                             "validationSilh" = clusterRange[which.max(avg_silh)],
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
-  
+
   kfit <- kmeans(dataset[, options[["predictors"]]],
                  centers = clusters,
                  iter.max = options[['noOfIterations']],

--- a/R/mlClusteringRandomForest.R
+++ b/R/mlClusteringRandomForest.R
@@ -53,17 +53,17 @@ mlClusteringRandomForest <- function(jaspResults, dataset, options, ...) {
 
   # Create the cluster plot
   .tsneClusterPlot(dataset, options, jaspResults, ready, position = 9, type = "randomForest")
-  
+
 }
 
 .randomForestClustering <- function(dataset, options, jaspResults){
 
 if(options[["modelOpt"]] == "validationManual"){
-      
-    rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
-										y = NULL, 
-										ntree = options[["noOfTrees"]], 
-										proximity = TRUE, 
+
+    rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]],
+										y = NULL,
+										ntree = options[["noOfTrees"]],
+										proximity = TRUE,
 										oob.prox = TRUE)
 
     clusters <- options[['noOfClusters']]
@@ -78,10 +78,10 @@ if(options[["modelOpt"]] == "validationManual"){
 
     startProgressbar(length(clusterRange))
 
-	rfit_tmp <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
-									y = NULL, 
-									ntree = options[["noOfTrees"]], 
-									proximity = TRUE, 
+	rfit_tmp <- randomForest::randomForest(x = dataset[, options[["predictors"]]],
+									y = NULL,
+									ntree = options[["noOfTrees"]],
+									proximity = TRUE,
 									oob.prox = TRUE)
 	hrfit_tmp <- hclust(as.dist(1 - rfit_tmp$proximity), method = "ward.D2")
 
@@ -92,7 +92,7 @@ if(options[["modelOpt"]] == "validationManual"){
       avg_silh[i - 1] <- silh[["avg.width"]]
 
 	  m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
-  
+
     wss_tmp <- numeric(i)
     for(j in 1:i) {
       if (m == 1) {
@@ -109,7 +109,7 @@ if(options[["modelOpt"]] == "validationManual"){
 	D <- sum(wss_tmp)
 	aicStore[i - 1] <- D + 2*m*k
 	bicStore[i - 1] <- D + log(n)*m*k
-      
+
     progressbarTick()
   }
 
@@ -118,10 +118,10 @@ if(options[["modelOpt"]] == "validationManual"){
                             "validationAIC" = clusterRange[which.min(aicStore)],
                             "validationBIC" = clusterRange[which.min(bicStore)])
 
-	rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]], 
-										y = NULL, 
-										ntree = options[["noOfTrees"]], 
-										proximity = TRUE, 
+	rfit <- randomForest::randomForest(x = dataset[, options[["predictors"]]],
+										y = NULL,
+										ntree = options[["noOfTrees"]],
+										proximity = TRUE,
 										oob.prox = TRUE)
 
   }
@@ -133,7 +133,7 @@ if(options[["modelOpt"]] == "validationManual"){
   size <- as.numeric(table(pred.values))
 
   m <- dim(as.data.frame(dataset[, options[["predictors"]]]))[2]
-  
+
   wss <- numeric(clusters)
   for(i in 1:clusters) {
     if (m == 1) {
@@ -182,13 +182,13 @@ if(options[["modelOpt"]] == "validationManual"){
 .randomForestClusteringVarImpTable <- function(options, jaspResults, ready, position){
 
   if (!is.null(jaspResults[["importanceTable"]]) || !options[["importanceTable"]]) return()
-  
+
   # Create table
   importanceTable <- createJaspTable(title = gettext("Variable Importance"))
   importanceTable$position <- position
   importanceTable$dependOn(options = c("predictors", "noOfClusters","noOfRandomSets", "noOfIterations", "algorithm", "modelOpt", "seed", "optimizationCriterion",
                                                       "maxClusters", "seedBox", "scaleEqualSD", "m", "distance", "linkage", "eps", "minPts", "noOfTrees", "maxTrees", "importanceTable"))
-  
+
   # Add column info
   importanceTable$addColumnInfo(name = "variable",  title = "", type = "string")
   importanceTable$addColumnInfo(name = "measure",  title = gettext("Mean decrease in Gini Index"), type = "number", format = "sf:4")
@@ -203,7 +203,7 @@ if(options[["modelOpt"]] == "validationManual"){
   ord <- order(varImp, decreasing = TRUE)
   name <- rownames(varImp)[ord]
   values <- as.numeric(varImp[ord])
-  
+
   # Add data per column
   row <- data.frame(variable = name, measure = values)
   importanceTable$addRows(row)

--- a/R/mlRegressionRegularized.R
+++ b/R/mlRegressionRegularized.R
@@ -16,13 +16,13 @@
 #
 
 mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
-  
+
 	# Preparatory work
 	dataset <- .readDataRegularizedRegression(dataset, options)
 	.errorHandlingRegressionAnalyses(dataset, options, type = "regularized")
-	
+
 	# Check if analysis is ready to run
-	ready <- .regressionAnalysesReady(options, type = "regularized")	
+	ready <- .regressionAnalysesReady(options, type = "regularized")
 
 	# Compute results and create the model summary table
 	.regressionMachineLearningTable(dataset, options, jaspResults, ready, position = 1, type = "regularized")
@@ -50,15 +50,15 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
 
   # Create the lambda evaluation plot
   .regressionRegularizedLambdaEvaluation(options, jaspResults, ready, position = 7)
-  
+
 }
 
 # Read dataset
 .readDataRegularizedRegression <- function(dataset, options){
-  
+
   target                    <- NULL
   weights                   <- NULL
-  testSetIndicator          <- NULL 
+  testSetIndicator          <- NULL
   if(options[["target"]] != "")
     target                  <- options[["target"]]
   if(options[["weights"]] != "")
@@ -72,10 +72,10 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   if (is.null(dataset)){
     dataset <- .readAndAddCompleteRowIndices(dataset, columnsAsNumeric = variables.to.read)
   }
-  
+
   if(length(unlist(options[["predictors"]])) > 0 && options[["target"]] != "" && options[["scaleEqualSD"]])
     dataset[,c(options[["predictors"]], options[["target"]])] <- .scaleNumericData(dataset[,c(options[["predictors"]], options[["target"]]), drop = FALSE])
-  
+
   return(dataset)
 }
 
@@ -115,7 +115,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   # Create the generated test set indicator
   testIndicatorColumn <- rep(1, nrow(dataset))
   testIndicatorColumn[train.index] <- 0
-  
+
   if(options[["modelOpt"]] == "optimizationManual"){
     # Just create a train and a test set (no optimization)
 		train                   <- trainAndValid
@@ -129,9 +129,9 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     test_target <- test[, options[["target"]]]
 
     regfit_train <- glmnet::cv.glmnet(x = train_pred, y = train_target, nfolds = 10, type.measure = "deviance",
-                                family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha, 
+                                family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha,
                                 standardize = FALSE, intercept = options[["intercept"]], thresh = options[["thresh"]])
-    
+
     lambda <- options[["lambda"]]
 
     pred_test <- predict(regfit_train, newx = test_pred, s = lambda, type = "link", exact = TRUE,
@@ -154,11 +154,11 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     valid_target <- valid[, options[["target"]]]
     test_pred <- as.matrix(test[,options[["predictors"]]])
     test_target <- test[, options[["target"]]]
-    
+
     regfit_train <- glmnet::cv.glmnet(x = train_pred, y = train_target, nfolds = 10, type.measure = "deviance",
-                                    family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha, 
+                                    family = "gaussian", weights = weights_train, offset = NULL, alpha = alpha,
                                     standardize = FALSE, intercept = options[["intercept"]], thresh = options[["thresh"]])
-    
+
     lambda <- base::switch(options[["modelOpt"]],
                             "optMin" = regfit_train[["lambda.min"]],
                             "opt1SE" = regfit_train[["lambda.1se"]])
@@ -171,12 +171,12 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
                           x = train_pred, y = train_target, weights = weights_train, offset = NULL,
                           alpha = alpha, standardize = FALSE, intercept = options[["intercept"]], thresh = options[["thresh"]])
   }
-  
+
   # Use the specified model to make predictions for dataset
   predictions <- predict(regfit_train, newx = as.matrix(dataset[,options[["predictors"]]]), s = lambda, type = "link", exact = TRUE,
                           x = as.matrix(dataset[,options[["predictors"]]]), y = dataset[, options[["target"]]], weights = weights, offset = NULL,
                           alpha = alpha, standardize = FALSE, intercept = options[["intercept"]], thresh = options[["thresh"]])
-  
+
   regressionResult <- list()
   regressionResult[["model"]]               <- regfit_train
   regressionResult[["lambda"]]              <- lambda
@@ -197,7 +197,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     regressionResult[["validMSE"]]          <- mean( (as.numeric(pred_valid) -  valid[,options[["target"]]])^2 )
     regressionResult[["nvalid"]]            <- nrow(valid)
   }
-  
+
   return(regressionResult)
 }
 
@@ -212,7 +212,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
                                           "penalty", "alpha", "thresh", "intercept", "modelOpt", "lambda",
                                           "testSetIndicatorVariable", "testSetIndicator", "validationDataManual",
                                           "holdoutData", "testDataManual"))
-  
+
   coefTable$addColumnInfo(name = "var",  title = "", type = "string")
   coefTable$addColumnInfo(name = "coefs",  title = gettextf("Coefficient (%s)", "\u03B2"), type = "number")
 
@@ -224,7 +224,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
       varStrings <- c("(Intercept)", varStrings)
     coefTable[["var"]]   <- varStrings
   }
-  
+
   if(!ready)  return()
 
   regressionResult <- jaspResults[["regressionResult"]]$object
@@ -238,7 +238,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
     labs <- c("(Intercept)", rownames(coefTab)[-1])
     values <- as.numeric(coefTab)
   }
-  
+
   coefTable[["var"]]   <- labs
   coefTable[["coefs"]] <- values
 }
@@ -258,7 +258,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
 
   if(!ready) return()
 
-  regressionResult <- jaspResults[["regressionResult"]]$object  
+  regressionResult <- jaspResults[["regressionResult"]]$object
 
   model         <- regressionResult[["model"]]$glmnet.fit
   coefs         <- as.matrix(regressionResult[["model"]]$glmnet.fit$beta)
@@ -272,7 +272,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   p <- ggplot2::ggplot(data = d, mapping = ggplot2::aes(x = lambda, y = values, colour = ind), show.legend = TRUE) +
         jaspGraphs::geom_line() +
         ggplot2::scale_x_continuous("\u03BB", breaks = xBreaks, labels = xBreaks) +
-        ggplot2::scale_y_continuous(gettext("Coefficients"), breaks = yBreaks, labels = yBreaks) + 
+        ggplot2::scale_y_continuous(gettext("Coefficients"), breaks = yBreaks, labels = yBreaks) +
         ggplot2::scale_color_manual(values = colorspace::qualitative_hcl(n = length(options[["predictors"]]))) +
         ggplot2::labs(color = "")
 
@@ -281,7 +281,7 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
   } else {
     p <- jaspGraphs::themeJasp(p)
   }
-  
+
   variableTrace$plotObject <- p
 }
 
@@ -300,13 +300,13 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
 
   if(!ready) return()
 
-  regressionResult <- jaspResults[["regressionResult"]]$object 
+  regressionResult <- jaspResults[["regressionResult"]]$object
 
   tempValues <- c(regressionResult[["cvMSELambda"]]$MSE - regressionResult[["cvMSELambda"]]$sd, regressionResult[["cvMSELambda"]]$MSE + regressionResult[["cvMSELambda"]]$sd)
 
   xBreaks <- jaspGraphs::getPrettyAxisBreaks(regressionResult[["cvMSELambda"]]$lambda, min.n = 4)
-  yBreaks <- jaspGraphs::getPrettyAxisBreaks(tempValues, min.n = 4) 
-  
+  yBreaks <- jaspGraphs::getPrettyAxisBreaks(tempValues, min.n = 4)
+
   p <- ggplot2::ggplot(data = regressionResult[["cvMSELambda"]], mapping = ggplot2::aes(x = lambda, y = MSE)) +
         ggplot2::geom_ribbon(data = regressionResult[["cvMSELambda"]], mapping = ggplot2::aes(ymin = MSE - sd, ymax = MSE + sd), fill = "grey90") +
         jaspGraphs::geom_line() +
@@ -315,12 +315,12 @@ mlRegressionRegularized <- function(jaspResults, dataset, options, ...) {
         ggplot2::geom_vline(ggplot2::aes(xintercept = regressionResult[["model"]]$lambda.min, color = "lambdaMin"), linetype = "dashed") +
         ggplot2::geom_vline(ggplot2::aes(xintercept = regressionResult[["model"]]$lambda.1se, color = "lambda1se"), linetype = "dashed") +
         ggplot2::scale_color_manual(name = "", values = c(lambdaMin = "#14a1e3", lambda1se = "#99c454"), labels = c(lambdaMin = gettext("Min. CV MSE"), lambda1se = gettextf("%s 1 SE", "\u03BB")))
-  
+
   if(options[["lambdaEvaluationLegend"]]){
     p <- jaspGraphs::themeJasp(p, legend.position = "top")
   } else {
     p <- jaspGraphs::themeJasp(p)
   }
-  
+
   lambdaEvaluation$plotObject <- p
 }


### PR DESCRIPTION
To avoid the need for a dependency on `gbm` within `jaspBase`

It also looks like a good idea to undo the overwriting of the functions again in an `on.exit`, but I wasn't sure if these functions are used outside of `.boostingClassification` and `.boostingRegression` as well. Maybe someone else knows.