### PR TITLE
Make axes labels in decision boundary matrix NULL instead of ""

### DIFF
--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -351,26 +351,13 @@
 
   for (row in 2:l) {
     for (col in 1:(l-1)) {
-      if (row == col) {
-          p <- jaspGraphs::drawAxis(xName = NULL, yName = NULL, force = TRUE) + adjMargin
-          p <- jaspGraphs::themeJasp(p)
-
-          plotMat[[row, col]] <- p
-      }
       if (col < row) {
           predictors <- dataset[, variables]
           predictors <- predictors[, c(col, row)]
           formula <- formula(paste(options[["target"]], "~", paste(colnames(predictors), collapse=" + ")))
           plotMat[[row-1, col]] <- .decisionBoundaryPlot(dataset, options, jaspResults, predictors, target, formula, l, type = type)
       }
-      if (col > row) {
-          p <- jaspGraphs::drawAxis(xName = NULL, yName = NULL, force = TRUE) + adjMargin
-          p <- jaspGraphs::themeJasp(p)
-
-          plotMat[[row, col]] <- p
-      }
-      if(l > 2)
-      if(options[["plotLegend"]])
+      if(l > 2 && options[["plotLegend"]])
         plotMat[[1, 2]] <- .legendPlot(dataset, options, col)
       progressbarTick()
     }
@@ -441,7 +428,7 @@
     if(options[["plotPoints"]])
       p <- p + jaspGraphs::geom_point(data = pointData, ggplot2::aes(x = x, y = y, fill = target))
     if(l <= 2){
-      p <- jaspGraphs::themeJasp(p, xAxis = TRUE, yAxis = TRUE, legend.position = "right")
+      p <- jaspGraphs::themeJasp(p, xAxis = TRUE, yAxis = TRUE, legend.position = if(options[["plotLegend"]]) "right" else "none")
     } else {
       p <- jaspGraphs::themeJasp(p, xAxis = TRUE, yAxis = TRUE)
     }

--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -352,9 +352,7 @@
   for (row in 2:l) {
     for (col in 1:(l-1)) {
       if (row == col) {
-          p <- jaspGraphs::drawAxis(xName = "", yName = "", force = TRUE) + adjMargin
-          p <- p + ggplot2::xlab("")
-          p <- p + ggplot2::ylab("")
+          p <- jaspGraphs::drawAxis(xName = NULL, yName = NULL, force = TRUE) + adjMargin
           p <- jaspGraphs::themeJasp(p)
 
           plotMat[[row, col]] <- p
@@ -366,9 +364,7 @@
           plotMat[[row-1, col]] <- .decisionBoundaryPlot(dataset, options, jaspResults, predictors, target, formula, l, type = type)
       }
       if (col > row) {
-          p <- jaspGraphs::drawAxis(xName = "", yName = "", force = TRUE) + adjMargin
-          p <- p + ggplot2::xlab("")
-          p <- p + ggplot2::ylab("")
+          p <- jaspGraphs::drawAxis(xName = NULL, yName = NULL, force = TRUE) + adjMargin
           p <- jaspGraphs::themeJasp(p)
 
           plotMat[[row, col]] <- p
@@ -385,6 +381,7 @@
   labelPos <- matrix(.5, 4, 2)
   labelPos[1, 1] <- .55
   labelPos[4, 2] <- .65
+
   p <- jaspGraphs::ggMatrixPlot(plotList = plotMat, leftLabels = variables[-1], topLabels = variables[-length(variables)],
                                 scaleXYlabels = NULL, labelPos = labelPos)
 
@@ -438,9 +435,9 @@
     p <- ggplot2::ggplot(data = gridData, mapping = ggplot2::aes(x = x, y = y)) +
           ggplot2::geom_tile(ggplot2::aes(fill = preds), alpha = 0.3, show.legend = FALSE) +
           ggplot2::labs(fill = options[["target"]]) +
-          ggplot2::scale_fill_manual(values = colorspace::qualitative_hcl(n = length(unique(target))))
-    p <- p + ggplot2::scale_x_continuous(name = "", breaks = xBreaks, limits = range(xBreaks))
-    p <- p + ggplot2::scale_y_continuous(name = "", breaks = yBreaks, limits = range(yBreaks))
+          ggplot2::scale_fill_manual(values = colorspace::qualitative_hcl(n = length(unique(target)))) +
+          ggplot2::scale_x_continuous(name = NULL, breaks = xBreaks, limits = range(xBreaks)) + 
+          ggplot2::scale_y_continuous(name = NULL, breaks = yBreaks, limits = range(yBreaks))
     if(options[["plotPoints"]])
       p <- p + jaspGraphs::geom_point(data = pointData, ggplot2::aes(x = x, y = y, fill = target))
     if(l <= 2){
@@ -460,14 +457,15 @@
 
   p <- ggplot2::ggplot(lda.data, ggplot2::aes(y = target, x = target, show.legend = TRUE)) +
         jaspGraphs::geom_point(ggplot2::aes(fill = target), alpha = 0) +
-        ggplot2::xlab("") +
-        ggplot2::ylab("") +
+        ggplot2::xlab(NULL) +
+        ggplot2::ylab(NULL) +
         ggplot2::theme(legend.key = ggplot2::element_blank()) +
         ggplot2::labs(fill = options[["target"]]) +
         ggplot2::scale_fill_manual(values = colorspace::qualitative_hcl(n = length(unique(target))))
-  p <- jaspGraphs::themeJasp(p, yAxis = FALSE, xAxis = FALSE, legend.position = "left")
-  p <- p + ggplot2::theme(axis.ticks = ggplot2::element_blank(), axis.text.x = ggplot2::element_blank(), axis.text.y = ggplot2::element_blank())
-  p <- p + ggplot2::guides(fill = ggplot2::guide_legend(override.aes = list(alpha = 1)))
+  
+  p <- jaspGraphs::themeJasp(p, yAxis = FALSE, xAxis = FALSE, legend.position = "left") +
+        ggplot2::theme(axis.ticks = ggplot2::element_blank(), axis.text.x = ggplot2::element_blank(), axis.text.y = ggplot2::element_blank()) +
+        ggplot2::guides(fill = ggplot2::guide_legend(override.aes = list(alpha = 1)))
 
   return(p)
 }

--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -342,7 +342,6 @@
   cexText <- 1.6
 
   plotMat <- matrix(list(), l - 1, l - 1)
-  adjMargin <- ggplot2::theme(plot.margin = ggplot2::unit(c(.25, .40, .25, .25), "cm"))
   oldFontSize <- jaspGraphs::getGraphOption("fontsize")
   jaspGraphs::setGraphOption("fontsize", .85 * oldFontSize)
 


### PR DESCRIPTION
Attempt to fix https://github.com/jasp-stats/INTERNAL-jasp/issues/1394, I've implemented axes labels as `NULL` in the decision boundary matrix.

This does not fix the issue with axes labels far away if there is only 1 plot. However, the plots are now slightly closer to each other, is this something we want @vandenman? It seems as if the plots get more 'gritty' now that they have more space. We might opt to not implement this in the end.

Before:
![image](https://user-images.githubusercontent.com/25059399/121353060-befe9a00-c92d-11eb-9975-4ff6faee6a75.png)

After:
![image](https://user-images.githubusercontent.com/25059399/121353328-08e78000-c92e-11eb-83bd-7024b20d6016.png)
