### PR TITLE
Use percentage formatting for validation measures

### DIFF
--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -527,10 +527,14 @@
   table <- createJaspTable(title = gettext("Model Performance Metrics"))
   table$position <- position
   table$dependOn(options = c(.mlRegressionDependencies(options), "validationMeasures"))
-  table$addColumnInfo(name = "measures", title = "", type = "string")
-  table$addColumnInfo(name = "values", title = gettext("Value"), type = "string")
-  measures <- c("MSE", gettext("MSE(scaled)"), "RMSE", "MAE / MAD", "MAPE", "R\u00B2")
-  table[["measures"]] <- measures
+  table$addColumnInfo(name = "colTitle", title = "", type = "string")
+  table$addColumnInfo(name = "mse", title = "MSE", type = "number")
+  table$addColumnInfo(name = "mse_scaled", title = gettext("MSE(scaled)"), type = "number")
+  table$addColumnInfo(name = "rmse", title = "RMSE", type = "number")
+  table$addColumnInfo(name = "mae", title = "MAE / MAD", type = "number")
+  table$addColumnInfo(name = "mape", title = "MAPE", type = "number", format = "pc")
+  table$addColumnInfo(name = "r_squared", title = "R\u00B2", type = "number")
+  table$transpose <- TRUE
   jaspResults[["validationMeasures"]] <- table
   if (!ready) {
     return()
@@ -540,16 +544,22 @@
   predDat <- predDat[complete.cases(predDat), ]
   obs <- predDat[["obs"]]
   pred <- predDat[["pred"]]
-  mse <- round(regressionResult[["testMSE"]], 3)
+  mse <- regressionResult[["testMSE"]]
   obs_scaled <- (obs - mean(obs)) / sd(obs)
   pred_scaled <- (pred - mean(pred)) / sd(pred)
-  mse_scaled <- round(mean((obs_scaled - pred_scaled)^2), 3)
-  rmse <- round(sqrt(mse), 3)
-  mae <- round(mean(abs(obs - pred)), 3)
-  mape <- paste0(round(mean(abs((obs - pred) / obs)) * 100, 2), "%")
-  r_squared <- round(cor(obs, pred)^2, 3)
-  values <- c(mse, mse_scaled, rmse, mae, mape, r_squared)
-  table[["values"]] <- values
+  mse_scaled <- mean((obs_scaled - pred_scaled)^2)
+  rmse <- sqrt(mse)
+  mae <- mean(abs(obs - pred))
+  mape <- mean(abs((obs - pred) / obs))
+  r_squared <- cor(obs, pred)^2
+  table[["colTitle"]] <- gettext("Values")
+  table[["mse"]] <- mse
+  table[["mse_scaled"]] <- mse_scaled
+  table[["mae"]] <- mae
+  table[["mape"]] <- mape
+  table[["rmse"]] <- rmse
+  table[["mape"]] <- mape
+  table[["r_squared"]] <- r_squared
   if (is.na(r_squared)) {
     table$addFootnote(gettextf("R%s cannot be computed due to lack of variance in the predictions.</i>", "\u00B2"))
   }

--- a/tests/testthat/test-mlregressionboosting.R
+++ b/tests/testthat/test-mlregressionboosting.R
@@ -53,9 +53,6 @@ options$predictors <- list("Malic", "Ash", "Alcalinity", "Magnesium", "Phenols",
                            "Nonflavanoids", "Proanthocyanins", "Color", "Hue", "Dilution",
                            "Proline")
 options$predictors.types <- rep("scale", length(options$predictors))
-options$predictors.types <- rep("scale", length(options$predictors))
-options$predictors.types <- rep("scale", length(options$predictors))
-options$predictors.types <- rep("scale", length(options$predictors))
 options$setSeed <- TRUE
 options$target <- "Alcohol"
 options$target.types <- "scale"
@@ -122,8 +119,8 @@ test_that("Boosting Regression table results match", {
 test_that("Evaluation Metrics table results match", {
   table <- results[["results"]][["validationMeasures"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list("MSE", 0.28, "MSE(scaled)", 0.374, "RMSE", 0.529, "MAE / MAD", 0.425, "MAPE", "3.33%",
-                           "R<unicode><unicode>", 0.652))
+                      list("Values", 0.425372298267314, 0.0332803311026787, 0.280491345224988,
+	 0.373676054903572, 0.652325557162448, 0.529614336309911))
 })
 
 test_that("Feature Contributions to Predictions for Test Set Cases table results match", {

--- a/tests/testthat/test-mlregressiondecisiontree.R
+++ b/tests/testthat/test-mlregressiondecisiontree.R
@@ -107,6 +107,6 @@ test_that("Additive Explanations for Predictions of Test Set Cases table results
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.18, "MSE(scaled)", 0.349, "RMSE", 0.424, "MAE / MAD", 0.354, "MAPE", "6.01%",
-			 "R<unicode>", 0.671))
+		list("Values", 0.354130485527544, 0.0600871978449155, 0.180120741111441,
+	 0.349303919563206, 0.671294371379323, 0.424406339622114))
 })

--- a/tests/testthat/test-mlregressionknn.R
+++ b/tests/testthat/test-mlregressionknn.R
@@ -95,8 +95,8 @@ test_that("K-Nearest Neighbors Regression table results match", {
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.379, "MSE(scaled)", 0.583, "RMSE", 0.616, "MAE / MAD", 0.512, "MAPE", "3.98%",
-			 "R<unicode>", 0.49))
+		list("Values", 0.5115, 0.0397883922098345, 0.37930375, 0.582791945895268,
+	 0.490046981289794, 0.615876408056032))
 })
 
 test_that("Feature Importance Metrics table results match", {

--- a/tests/testthat/test-mlregressionlinear.R
+++ b/tests/testthat/test-mlregressionlinear.R
@@ -78,6 +78,6 @@ test_that("Additive Explanations for Predictions of Test Set Cases table results
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.079, "MSE(scaled)", 0.023, "RMSE", 0.281, "MAE / MAD", 0.228, "MAPE", "8.08%",
-			 "R<unicode>", 0.976))
+		list("Values", 0.228083959876927, 0.0808497679064431, 0.0792006506573426,
+	 0.0231629075719563, 0.976181911387651, 0.281426101592128))
 })

--- a/tests/testthat/test-mlregressionneuralnetwork.R
+++ b/tests/testthat/test-mlregressionneuralnetwork.R
@@ -54,8 +54,8 @@ test_that("Neural Network Regression table results match", {
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.089, "MSE(scaled)", 0.156, "RMSE", 0.298, "MAE / MAD", 0.243, "MAPE", "4.18%",
-			 "R<unicode>", 0.845))
+		list("Values", 0.243447601838486, 0.0418476947998267, 0.0887985623673364,
+	 0.156456043905222, 0.844697863114405, 0.297990876315595))
 })
 
 test_that("Additive Explanations for Predictions of Test Set Cases table results match", {

--- a/tests/testthat/test-mlregressionrandomforest.R
+++ b/tests/testthat/test-mlregressionrandomforest.R
@@ -174,8 +174,8 @@ test_that("Evaluation Metrics table results match", {
   testthat::skip_on_os(c("windows", "linux"))
   table <- results[["results"]][["validationMeasures"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list("MSE", 0.355, "MSE(scaled)", 0.531, "RMSE", 0.596, "MAE / MAD", 0.474, "MAPE", "3.72%",
-                           "R<unicode><unicode>", 0.528))
+                      list("Values", 0.474173308270677, 0.0371687545468009, 0.355223330180166,
+	 0.530948953827784, 0.528118252477076, 0.59600614944828))
 })
 
 test_that("Feature Importance Metrics table results match", {

--- a/tests/testthat/test-mlregressionrandomforest.R
+++ b/tests/testthat/test-mlregressionrandomforest.R
@@ -121,8 +121,8 @@ test_that("Evaluation Metrics table results match", {
   testthat::skip_on_os("mac")
   table <- results[["results"]][["validationMeasures"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list("MSE", 0.355, "MSE(scaled)", 0.531, "RMSE", 0.596, "MAE / MAD", 0.473, "MAPE", "3.71%",
-                           "R<unicode><unicode>", 0.528))
+                      list("Values", 0.474173308270677, 0.0371687545468009, 0.355223330180166,
+	 0.530948953827784, 0.528118252477076, 0.59600614944828))
 })
 
 test_that("Feature Importance Metrics table results match", {

--- a/tests/testthat/test-mlregressionrandomforest.R
+++ b/tests/testthat/test-mlregressionrandomforest.R
@@ -121,8 +121,8 @@ test_that("Evaluation Metrics table results match", {
   testthat::skip_on_os("mac")
   table <- results[["results"]][["validationMeasures"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                      list("Values", 0.474173308270677, 0.0371687545468009, 0.355223330180166,
-	 0.530948953827784, 0.528118252477076, 0.59600614944828))
+                      list("Values", 0.473497619047619, 0.0371154907694286, 0.355223330180166,
+	 0.531126446557653, 0.527985480021831, 0.59600614944828))
 })
 
 test_that("Feature Importance Metrics table results match", {

--- a/tests/testthat/test-mlregressionregularized.R
+++ b/tests/testthat/test-mlregressionregularized.R
@@ -97,8 +97,8 @@ test_that("Regularized Linear Regression table results match", {
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.316, "MSE(scaled)", 0.504, "RMSE", 0.562, "MAE / MAD", 0.428, "MAPE", "3.34%",
-			 "R<unicode>", 0.549))
+		list("Values", 0.427706057315286, 0.0333852369095772, 0.315722256934242,
+	 0.503930362151054, 0.548524025364545, 0.561891677224571))
 })
 
 test_that("Variable Trace Plot matches", {

--- a/tests/testthat/test-mlregressionsvm.R
+++ b/tests/testthat/test-mlregressionsvm.R
@@ -198,6 +198,6 @@ test_that("Additive Explanations for Predictions of Test Set Cases table results
 test_that("Model Performance Metrics table results match", {
 	table <- results[["results"]][["validationMeasures"]][["data"]]
 	jaspTools::expect_equal_tables(table,
-		list("MSE", 0.079, "MSE(scaled)", 0.149, "RMSE", 0.281, "MAE / MAD", 0.234, "MAPE", "4.05%",
-			 "R<unicode>", 0.852))
+		list("Values", 0.233880681803325, 0.0405178555867029, 0.0785792724199296,
+	 0.14900759463868, 0.851794443398157, 0.280319946525269))
 })


### PR DESCRIPTION
Implement 'pc' number format instead of having strings with "%" pasted behind them.