### PR TITLE
Class probabilities in prediction analysis

### DIFF
--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -786,7 +786,7 @@
   } else {
     explainer <- model[["explainer"]]
     x_test <- dataset[, predictors]
-    predictions <- .mlPredictionsState(model, dataset, options, jaspResults, ready)[options[["fromIndex"]]:options[["toIndex"]]]
+    predictions <- .mlPredictionsState(model, dataset, options, jaspResults, ready)[[1]][options[["fromIndex"]]:options[["toIndex"]]]
   }
   from <- min(c(options[["fromIndex"]], options[["toIndex"]] - 1, nrow(x_test)))
   to <- min(c(options[["toIndex"]], nrow(x_test)))

--- a/R/mlPrediction.R
+++ b/R/mlPrediction.R
@@ -88,8 +88,8 @@ is.jaspMachineLearning <- function(x) {
 }
 .mlPredictionGetPredictions.kknn <- function(model, dataset) {
   if (inherits(model, "jaspClassification")) {
-    hard <- as.character(kknn:::predict.train.kknn(model[["predictive"]], dataset))
     soft <- kknn:::predict.train.kknn(model[["predictive"]], dataset, type = "prob")
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
     return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(kknn:::predict.train.kknn(model[["predictive"]], dataset))
@@ -97,8 +97,8 @@ is.jaspMachineLearning <- function(x) {
   }
 }
 .mlPredictionGetPredictions.lda <- function(model, dataset) {
-  hard <- as.character(MASS:::predict.lda(model, newdata = dataset)$class)
   soft <- MASS:::predict.lda(model, newdata = dataset)$posterior
+  hard <- colnames(soft)[max.col(soft, ties.method = "random")]
   return(list(hard, soft))
 }
 .mlPredictionGetPredictions.lm <- function(model, dataset) {
@@ -107,9 +107,9 @@ is.jaspMachineLearning <- function(x) {
 }
 .mlPredictionGetPredictions.gbm <- function(model, dataset) {
   if (inherits(model, "jaspClassification")) {
-    soft <- gbm:::predict.gbm(model, newdata = dataset, n.trees = model[["n.trees"]], type = "response")
-    hard <- as.character(colnames(soft)[apply(soft, 1, which.max)])
-    return(list(hard, soft[, , 1]))
+    soft <- gbm:::predict.gbm(model, newdata = dataset, n.trees = model[["n.trees"]], type = "response")[, , 1]
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
+    return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(gbm:::predict.gbm(model, newdata = dataset, n.trees = model[["n.trees"]], type = "response"))
     return(list(hard))
@@ -117,8 +117,8 @@ is.jaspMachineLearning <- function(x) {
 }
 .mlPredictionGetPredictions.randomForest <- function(model, dataset) {
   if (inherits(model, "jaspClassification")) {
-    hard <- as.character(randomForest:::predict.randomForest(model, newdata = dataset))
     soft <- predict(model, newdata = dataset, type = "prob")
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
     return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(randomForest:::predict.randomForest(model, newdata = dataset))
@@ -133,7 +133,7 @@ is.jaspMachineLearning <- function(x) {
   if (inherits(model, "jaspClassification")) {
     soft <- neuralnet:::predict.nn(model, newdata = dataset)
     colnames(soft) <- levels(factor(model[["data"]][[model[["jaspVars"]][["encoded"]]$target]]))
-    hard <- colnames(soft)[apply(soft, 1, which.max)]
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
     return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(neuralnet:::predict.nn(model, newdata = dataset))
@@ -144,7 +144,7 @@ is.jaspMachineLearning <- function(x) {
   if (inherits(model, "jaspClassification")) {
     soft <- rpart:::predict.rpart(model, newdata = dataset)
     colnames(soft) <- levels(factor(model[["data"]][[model[["jaspVars"]][["encoded"]]$target]]))
-    hard <- colnames(soft)[apply(soft, 1, which.max)]
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
     return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(rpart:::predict.rpart(model, newdata = dataset))
@@ -154,7 +154,7 @@ is.jaspMachineLearning <- function(x) {
 .mlPredictionGetPredictions.svm <- function(model, dataset) {
   if (inherits(model, "jaspClassification")) {
     soft <- attr(e1071:::predict.svm(model, newdata = dataset, probability = TRUE), "probabilities")
-    hard <- as.character(e1071:::predict.svm(model, newdata = dataset))
+    hard <- colnames(soft)[max.col(soft, ties.method = "random")]
     return(list(hard, soft))
   } else if (inherits(model, "jaspRegression")) {
     hard <- as.numeric(e1071:::predict.svm(model, newdata = dataset))
@@ -163,14 +163,14 @@ is.jaspMachineLearning <- function(x) {
 }
 .mlPredictionGetPredictions.naiveBayes <- function(model, dataset) {
   soft <- e1071:::predict.naiveBayes(model, newdata = dataset, type = "raw")
-  hard <- as.character(e1071:::predict.naiveBayes(model, newdata = dataset, type = "class"))
+  hard <- colnames(soft)[max.col(soft, ties.method = "random")]
   return(list(hard, soft))
 }
 .mlPredictionGetPredictions.glm <- function(model, dataset) {
   probs <- predict(model, newdata = dataset, type = "response")
   soft <- matrix(c(1 - probs, probs), ncol = 2)
   colnames(soft) <- levels(as.factor(model$model[[model[["jaspVars"]][["encoded"]]$target]]))
-  hard <- colnames(soft)[apply(soft, 1, which.max)]
+  hard <- colnames(soft)[max.col(soft, ties.method = "random")]
   return(list(hard, soft))
 }
 .mlPredictionGetPredictions.vglm <- function(model, dataset) {
@@ -183,7 +183,7 @@ is.jaspMachineLearning <- function(x) {
   soft[, ncategories] <- 1
   soft <- soft / rowSums(soft)
   colnames(soft) <- as.character(levels(as.factor(model$target)))
-  hard <- colnames(soft)[apply(soft, 1, which.max)]
+  hard <- colnames(soft)[max.col(soft, ties.method = "random")]
   return(list(hard, soft))
 }
 

--- a/inst/qml/common/ui/ExportResults.qml
+++ b/inst/qml/common/ui/ExportResults.qml
@@ -53,7 +53,7 @@ Group
 			name:					"addProbabilities"
 			text:					qsTr("Add probabilities (classification only)")
 			visible:				showProbs
-			info:					qsTr("In classification analyses, also add the predicted probabilities for each class to the data.")
+			info:					qsTr("In classification analyses, append the predicted probabilities for each class to the data. For neural networks, this option provides the output of the final layer.")
 		}
 	}
 

--- a/inst/qml/common/ui/ExportResults.qml
+++ b/inst/qml/common/ui/ExportResults.qml
@@ -24,6 +24,7 @@ Group
 {
 	property alias enabled:			exportSection.enabled
 	property alias showSave:		saveGroup.visible
+	property bool showProbs:		false
 
 	id:								exportSection
 	title:							qsTr("Export Results")
@@ -44,6 +45,15 @@ Group
 			fieldWidth:				120
 			enabled:				addPredictions.checked
 			info:					qsTr("The column name for the predicted values.")
+		}
+
+		CheckBox
+		{
+			id:						probabilities
+			name:					"addProbabilities"
+			text:					qsTr("Add probabilities (classification only)")
+			visible:				showProbs
+			info:					qsTr("In classification analyses, also add the predicted probabilities for each class to the data.")
 		}
 	}
 

--- a/inst/qml/mlPrediction.qml
+++ b/inst/qml/mlPrediction.qml
@@ -116,5 +116,6 @@ Form
 	UI.ExportResults {
 		enabled:								predictors.count > 1
 		showSave:								false
+		showProbs:								true
 	}
 }


### PR DESCRIPTION
Add the option to add the predicted class probabilities to the data set in the prediction analysis

- Closes https://github.com/jasp-stats/jasp-issues/issues/3340
- Closes https://github.com/jasp-stats/jasp-issues/issues/3127

Steps to test:
1. Train a machine learning classification model
2. Save it to a .jaspML file using the interface
3. Load it into the prediction analysis
4. Add the predictions (including class probabilities) to the dataset