### PR TITLE
More intuitive save model logic

### DIFF
--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -167,14 +167,14 @@
   if (!ready) {
     table$addFootnote(gettextf("Please provide a target variable and at least %i feature variable(s).", if (type == "knn" || type == "neuralnet" || type == "rpart" || type == "svm" || type == "logistic") 1L else 2L))
   }
-  if (options[["savePath"]] != "") {
+  if (options[["saveModel"]]) {
     validNames <- (length(grep(" ", decodeColNames(colnames(dataset)))) == 0) && (length(grep("_", decodeColNames(colnames(dataset)))) == 0)
-    if (options[["saveModel"]] && validNames) {
+    if (options[["savePath"]] != "" && validNames) {
       table$addFootnote(gettextf("The trained model is saved as <i>%1$s</i>.", basename(options[["savePath"]])))
-    } else if (options[["saveModel"]] && !validNames) {
+    } else if (options[["savePath"]] != "" && !validNames) {
       table$addFootnote(gettext("The trained model is <b>not</b> saved because the some of the variable names in the model contain spaces (i.e., ' ') or underscores (i.e., '_'). Please remove all such characters from the variable names and try saving the model again."))
     } else {
-      table$addFootnote(gettext("The trained model is not saved until 'Save trained model' is checked."))
+      table$addFootnote(gettext("The trained model is not saved until a file name is specified under 'Save as'."))
     }
   }
   jaspResults[["classificationTable"]] <- table

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -336,14 +336,14 @@
   if (!ready) {
     table$addFootnote(gettextf("Please provide a target variable and at least %d feature variable(s).", if (type == "knn" || type == "neuralnet" || type == "rpart" || type == "svm" || type == "lm") 1L else 2L))
   }
-  if (options[["savePath"]] != "") {
+  if (options[["saveModel"]]) {
     validNames <- (length(grep(" ", decodeColNames(colnames(dataset)))) == 0) && (length(grep("_", decodeColNames(colnames(dataset)))) == 0)
-    if (options[["saveModel"]] && validNames) {
+    if (options[["savePath"]] != "" && validNames) {
       table$addFootnote(gettextf("The trained model is saved as <i>%1$s</i>.", basename(options[["savePath"]])))
-    } else if (options[["saveModel"]] && !validNames) {
+    } else if (options[["savePath"]] != "" && !validNames) {
       table$addFootnote(gettext("The trained model is <b>not</b> saved because the some of the variable names in the model contain spaces (i.e., ' ') or underscores (i.e., '_'). Please remove all such characters from the variable names and try saving the model again."))
     } else {
-      table$addFootnote(gettext("The trained model is not saved until 'Save trained model' is checked."))
+      table$addFootnote(gettext("The trained model is not saved until a file name is specified under 'Save as'."))
     }
   }
   jaspResults[["regressionTable"]] <- table

--- a/inst/qml/common/ui/ExportResults.qml
+++ b/inst/qml/common/ui/ExportResults.qml
@@ -61,26 +61,22 @@ Group
 	{
 		id:							saveGroup
 
-		FileSelector
-		{
-			id:						savePath
-			name:					"savePath"
-			label:					qsTr("Save as")
-			placeholderText:		qsTr("e.g., location/model.jaspML")
-			filter:					"*.jaspML"
-			save:					true
-			fieldWidth:				180 * preferencesModel.uiScale
-			info:					qsTr("The file path for the saved model.")
-		}
-
 		CheckBox
 		{
-			id:						saveModel
 			name:					"saveModel"
 			text:					qsTr("Save trained model")
-			enabled:				showSave && savePath.value != ""
-			Layout.leftMargin:		10 * preferencesModel.uiScale
 			info:					qsTr("When clicked, the model is exported to the specified file path.")
+
+			FileSelector
+			{
+				name:				"savePath"
+				label:				qsTr("Save as")
+				placeholderText:	qsTr("e.g., location/model.jaspML")
+				filter:				"*.jaspML"
+				save:				true
+				fieldWidth:			180 * preferencesModel.uiScale
+				info:				qsTr("The file path for the saved model.")
+			}
 		}
 	}
 }


### PR DESCRIPTION
Instead of having to fill in the file path first and then checking the 'Save trained model box', now you have to check the 'Save trained model' box first and then specify the file path. This is likely more intuitive since it works this way for the save predictions functionality as well.

@vandenman What do you think about this? Is it more intuitive?

Before:
<img width="334" alt="image" src="https://github.com/user-attachments/assets/6fc27f5c-846c-4499-b9a2-bc8713f5f2e0" />

After:
<img width="334" alt="image" src="https://github.com/user-attachments/assets/658905c6-29d5-4092-8f1a-9045b68b972d" />