### PR TITLE
Automatically deduce scaling from trained model

### DIFF
--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -340,6 +340,7 @@
     model[["jaspVars"]] <- list()
     model[["jaspVars"]]$decoded <- list(target = decodeColNames(options[["target"]]), predictors = decodeColNames(options[["predictors"]]))
     model[["jaspVars"]]$encoded = list(target = options[["target"]], predictors = options[["predictors"]])
+    model[["jaspScaling"]] <- attr(dataset, "jaspScaling")
     model[["jaspVersion"]] <- .baseCitation
     model[["explainer"]] <- classificationResult[["explainer"]]
     class(model) <- c(class(classificationResult[["model"]]), "jaspClassification", "jaspMachineLearning")

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -501,6 +501,8 @@
     model[["jaspVars"]] <- list()
     model[["jaspVars"]]$decoded <- list(target = decodeColNames(options[["target"]]), predictors = decodeColNames(options[["predictors"]]))
     model[["jaspVars"]]$encoded = list(target = options[["target"]], predictors = options[["predictors"]])
+    model[["jaspScaling"]] <- .getJaspScaling(dataset[, options[["predictors"]], drop = FALSE])
+	print(model[["jaspScaling"]])
     model[["jaspVersion"]] <- .baseCitation
     model[["explainer"]] <- regressionResult[["explainer"]]
     class(model) <- c(class(regressionResult[["model"]]), "jaspRegression", "jaspMachineLearning")
@@ -681,6 +683,36 @@
     jaspResults[["testIndicatorColumn"]]$dependOn(options = c(.mlRegressionDependencies(options), "testIndicatorColumn", "addIndicator"))
     jaspResults[["testIndicatorColumn"]]$setNominal(testIndicatorColumn)
   }
+}
+
+.getJaspScaling <- function(x) {
+  idx <- sapply(x, function(x) is.numeric(x) && length(unique(x)) > 1)
+  colNames <- list(encoded = colnames(x), decoded = decodeColNames(colnames(x)))
+  cols_to_scale <- colNames[["decoded"]][idx]
+  centers <- setNames(numeric(length(cols_to_scale)), cols_to_scale)
+  scales <- setNames(numeric(length(cols_to_scale)), cols_to_scale)
+  for (col in cols_to_scale) {
+    encodedColName <- colNames[["encoded"]][which(colNames[["decoded"]] == col)]
+    centers[col] <- mean(x[[encodedColName]])
+    scales[col] <- sd(x[[encodedColName]])
+  }
+  return(list(centers, scaling))
+}
+
+.setJaspScaling <- function(x, center, scale) {
+  if (nrow(x) == 0) {
+    return(x)
+  }
+  idx <- sapply(x, function(x) is.numeric(x) && length(unique(x)) > 1)
+  colNames <- list(encoded = colnames(x), decoded = decodeColNames(colnames(x)))
+  cols_to_scale <- colNames[["decoded"]][idx]
+  for (col in cols_to_scale) {
+    encodedColName <- colNames[["encoded"]][which(colNames[["decoded"]] == col)]
+    x[, encodedColName] <- scale(x[, encodedColName, drop = FALSE], center = center[col], scale = scale[col])
+  }
+  attr(x, which = "scaled:center") <- NULL
+  attr(x, which = "scaled:scale") <- NULL
+  return(x)
 }
 
 # these could also extend the S3 method scale although that could be somewhat unexpected

--- a/R/mlPrediction.R
+++ b/R/mlPrediction.R
@@ -340,9 +340,9 @@ is.jaspMachineLearning <- function(x) {
     return()
   }
   if (is.null(model[["jaspScaling"]])) {
-    table$addFootnote(gettext("The features in the new data are unscaled."))
+    table$addFootnote(gettext("The features in the new data are unscaled, consistent with the training set."))
   } else {
-    table$addFootnote(gettext("The features in the new data are scaled."))
+    table$addFootnote(gettext("The features in the new data are scaled the same as those in the training set."))
   }
   modelVars_encoded <- model[["jaspVars"]][["encoded"]]$predictors
   modelVars_decoded <- model[["jaspVars"]][["decoded"]]$predictors

--- a/R/mlPrediction.R
+++ b/R/mlPrediction.R
@@ -274,13 +274,18 @@ is.jaspMachineLearning <- function(x) {
     dataset <- NULL
   } else {
     dataset <- jaspBase::excludeNaListwise(dataset, options[["predictors"]])
-    if (options[["scaleVariables"]] && length(unlist(options[["predictors"]])) > 0) {
-      dataset <- .scaleNumericData(dataset)
-    }
     # Select only the predictors in the model to prevent accidental double column names
     dataset <- dataset[, which(decodeColNames(colnames(dataset)) %in% model[["jaspVars"]][["decoded"]]$predictors), drop = FALSE]
     # Ensure the column names in the dataset match those in the training data
     colnames(dataset) <- .matchDecodedNames(colnames(dataset), model)
+    # Scale the features with the same scaling as the origingal dataset
+    if (options[["scaleVariables"]] && length(unlist(options[["predictors"]])) > 0) {
+      if (is.null(model[["jaspScaling"]])) {
+        dataset <- .scaleNumericData(dataset)
+      } else {
+        dataset <- .setJaspScaling(dataset, model$jaspScaling[[1]], model$jaspScaling[[2]])
+      }
+    }
     # Retrieve the training set
     trainingSet <- model[["explainer"]]$data
     # Check for factor levels in the test set that are not in the training set

--- a/R/mlPrediction.R
+++ b/R/mlPrediction.R
@@ -297,7 +297,7 @@ is.jaspMachineLearning <- function(x) {
       trainingSet <- model[["explainer"]]$data
       # Check for factor levels in the test set that are not in the training set
       .checkForNewFactorLevelsInPredictionSet(trainingSet, dataset, "prediction", model)
-      # Ensure factor variables in dataset have same levels as those in the training data
+      # Ensure that factor variables in the dataset have their levels ordered the same way as in the training data
       factorColumns <- colnames(dataset)[sapply(dataset, is.factor)]
       dataset[factorColumns] <- lapply(factorColumns, function(i) factor(dataset[[i]], levels = levels(trainingSet[[i]])))
     }

--- a/R/mlPrediction.R
+++ b/R/mlPrediction.R
@@ -286,7 +286,7 @@ is.jaspMachineLearning <- function(x) {
     dataset <- jaspBase::excludeNaListwise(dataset, options[["predictors"]])
     # Select only the predictors in the model to prevent accidental double column names
     dataset <- dataset[, which(decodeColNames(colnames(dataset)) %in% model[["jaspVars"]][["decoded"]]$predictors), drop = FALSE]
-    if (NCOL(dataset) > 0) {
+    if (NCOL(dataset) == length(model[["jaspVars"]][["decoded"]]$predictors)) {
       # Ensure the column names in the dataset match those in the training data
       colnames(dataset) <- .matchDecodedNames(colnames(dataset), model)
       # Scale the features with the same scaling as the original dataset

--- a/inst/qml/mlPrediction.qml
+++ b/inst/qml/mlPrediction.qml
@@ -59,13 +59,6 @@ Form
 
 	Group
 	{
-		title:									qsTr("Algorithmic Settings")
-
-		UI.ScaleVariables { }
-	}
-
-	Group
-	{
 		title:									qsTr("Tables")
 
 		CheckBox


### PR DESCRIPTION
I removed the 'scale variables' option from the prediction analysis and now deduce it from the trained model:
- If the features in the trained model were not scaled, the features for the new data will not be scaled either
- If the features in the trained model were scaled, the features for the new data will now be scaled in the same way (with the mean and sd of the original dataset)

I did this because I could not think of a scenario in which the user would scale the features in the prediction analysis if they were unscaled in training, or where the user would leave the features unscaled in the prediction while they were scaled in training. Removing the option entirely and deducing it from the trained model seemed more user-friendly and avoids confusion.

Issues:
- Closes https://github.com/jasp-stats/jaspMachineLearning/issues/413