### PR TITLE
Added functionality to balance sample size of each level of the target/label variable

### DIFF
--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -33,7 +33,7 @@
     "noOfTrees", "maxTrees", "baggingFraction", "noOfPredictors", "numberOfPredictors",   # Random forest
     "complexityParameter", "degree", "gamma", "cost", "tolerance", "epsilon", "maxCost",  # Support vector machine
     "smoothingParameter",                                                                 # Naive Bayes
-    "intercept", "link",
+    "intercept", "link",                                                                  # Logistic
 	  "balanceLabels"                                                                       # Common
   )
   if (includeSaveOptions) {

--- a/R/commonMachineLearningClassification.R
+++ b/R/commonMachineLearningClassification.R
@@ -42,7 +42,7 @@
   return(opt)
 }
 
-.balance_dataset <- function(dataset, options) {
+.mlBalanceDataset <- function(dataset, options) {
   # Extract targets and split data
   target <- dataset[, options[["target"]]]
   split_data <- split(dataset, target)
@@ -63,7 +63,7 @@
 
     # Balance Dataset based on selected Target
     if (options[["balanceLabels"]] == "balanced") {
-      dataset <- .balance_dataset(dataset, options)
+      dataset <- .mlBalanceDataset(dataset, options)
     }
 
     dataset[, options[["target"]]] <- factor(dataset[, options[["target"]]], ordered = FALSE)

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -36,7 +36,7 @@
     "mutationMethod", "survivalMethod", "elitismProportion", "candidates",                # Neural network
     "noOfTrees", "maxTrees", "baggingFraction", "noOfPredictors", "numberOfPredictors",   # Random forest
     "convergenceThreshold", "penalty", "alpha", "intercept", "lambda",                    # Regularized
-    "complexityParameter", "degree", "gamma", "cost", "tolerance", "epsilon", "maxCost"  # Support vector machine
+    "complexityParameter", "degree", "gamma", "cost", "tolerance", "epsilon", "maxCost"   # Support vector machine
   )
   if (includeSaveOptions) {
     opt <- c(opt, "saveModel", "savePath")

--- a/R/commonMachineLearningRegression.R
+++ b/R/commonMachineLearningRegression.R
@@ -36,7 +36,7 @@
     "mutationMethod", "survivalMethod", "elitismProportion", "candidates",                # Neural network
     "noOfTrees", "maxTrees", "baggingFraction", "noOfPredictors", "numberOfPredictors",   # Random forest
     "convergenceThreshold", "penalty", "alpha", "intercept", "lambda",                    # Regularized
-    "complexityParameter", "degree", "gamma", "cost", "tolerance", "epsilon", "maxCost"   # Support vector machine
+    "complexityParameter", "degree", "gamma", "cost", "tolerance", "epsilon", "maxCost"  # Support vector machine
   )
   if (includeSaveOptions) {
     opt <- c(opt, "saveModel", "savePath")
@@ -166,7 +166,7 @@
   if (length(factorsWithNewLevels) > 0) {
     setType <- switch(type, "test" = gettext("test set"), "validation" = gettext("validation set"), "prediction" = gettext("new dataset"))
     additionalMessage <- switch(type,
-      "test" = gettext(" or use a different test set (e.g., automatically by setting a different seed or manually by specifying the test set indicator)"), 
+      "test" = gettext(" or use a different test set (e.g., automatically by setting a different seed or manually by specifying the test set indicator)"),
       "validation" = gettext(" or use a different validation set by setting a different seed"),
       "prediction" = "")
     factorMessage <- paste(sapply(factorsWithNewLevels, function(i) {
@@ -597,7 +597,7 @@
   }
   plot <- createJaspPlot(plot = NULL, title = gettext("Data Split"), width = 800, height = 30)
   plot$position <- position
-  plot$dependOn(options = c("dataSplitPlot", "target", "predictors", "trainingDataManual", "modelValid", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual", "holdoutData", "testDataManual", "modelOptimization"))
+  plot$dependOn(options = c("balanceLabels", "dataSplitPlot", "target", "predictors", "trainingDataManual", "modelValid", "testSetIndicatorVariable", "testSetIndicator", "validationDataManual", "holdoutData", "testDataManual", "modelOptimization"))
   jaspResults[["plotDataSplit"]] <- plot
   if (!ready) {
     return()

--- a/inst/qml/common/ui/BalanceLabels.qml
+++ b/inst/qml/common/ui/BalanceLabels.qml
@@ -25,14 +25,14 @@ RadioButtonGroup
     title: qsTr("Whether to have equal distribution of labels in the data")
     RadioButton
     {
-        name: "balanced"
-        text: qsTr("Balance distribution of labels")
+        value: "balanced"
+        label: qsTr("Balance distribution of labels")
         checked: true
 
     }
     RadioButton
     {
-        name:"unbalanced" 
-        text: qsTr("Keep original distribution of labels")
+        value:"unbalanced" 
+        label: qsTr("Keep original distribution of labels")
     }
 }

--- a/inst/qml/common/ui/BalanceLabels.qml
+++ b/inst/qml/common/ui/BalanceLabels.qml
@@ -28,8 +28,8 @@ RadioButtonGroup
         value: "balanced"
         label: qsTr("Balance distribution of labels")
         checked: true
-
     }
+    
     RadioButton
     {
         value:"unbalanced" 

--- a/inst/qml/common/ui/BalanceLabels.qml
+++ b/inst/qml/common/ui/BalanceLabels.qml
@@ -1,0 +1,38 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+import QtQuick
+import QtQuick.Layouts
+import JASP.Controls
+
+RadioButtonGroup
+{
+    name: "balanceLabels"
+    title: qsTr("Whether to have equal distribution of labels in the data")
+    RadioButton
+    {
+        name: "balanced"
+        text: qsTr("Balance distribution of labels")
+        checked: true
+
+    }
+    RadioButton
+    {
+        name:"unbalanced" 
+        text: qsTr("Keep original distribution of labels")
+    }
+}

--- a/inst/qml/mlClassificationLogisticMultinomial.qml
+++ b/inst/qml/mlClassificationLogisticMultinomial.qml
@@ -95,4 +95,9 @@ Form
 			}
 		}
 	}
+	Section 
+	{
+		title: qsTr("Balancing Labels")
+		UI.BalanceLabels { }
+	}
 }

--- a/inst/qml/mlClassificationLogisticMultinomial.qml
+++ b/inst/qml/mlClassificationLogisticMultinomial.qml
@@ -98,6 +98,7 @@ Form
 	Section 
 	{
 		title: qsTr("Balancing Labels")
+		
 		UI.BalanceLabels { }
 	}
 }


### PR DESCRIPTION
Refers to issue [#457](https://github.com/jasp-stats/jaspMachineLearning/issues/457)

I've added a section in the QML interface to select whether the data should be balanced in sample size according to the selected target variable. I've also added the functionality in the R-scripts. This functionality is **only implemented in Logistic/Multinomial Regression so far!**

I've added this functionality very early in the analysis, namely in .mlClassificationReadData in **commonMachineLearningClassification**. The subfunction itself is called .mlBalanceDataset in the same script. 

Dependencies for the analysis option named "balanceLabels" is added in .mlClassificationDependencies, as well as in the specific function that produces the Data Split plot (.mlPlotDataSplit) in **commonMachineLearningRegression**. 

For the latter, this is because the Data Split plot is a default plot for the analysis, and because the dependencies in that plot function do not make use of the common dependencies in .mlClassificationDependencies. I did not check whether this is the case for other non-default plots and tables in the analysis, but all main tables of the analysis (which use .mlClassificationDependencies) reflect changes in the balanceLabels option. 

This is my first time making a contribution to a JASP module, please advise as to further steps that need to be taken by me!
